### PR TITLE
Add rustup update to the workflow to update rustc to the latest 1.66.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Update to Rust 1.66
+      run: rustup update
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Otherwise integration tests fail due to problems with the test output in older versions of the Rust test harness.