### PR TITLE
Migrate test helper binaries to run in the Rust test harness.

### DIFF
--- a/googletest/integration_tests/assertion_failure_in_subroutine.rs
+++ b/googletest/integration_tests/assertion_failure_in_subroutine.rs
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(google3))]
-use googletest::matchers;
-use googletest::{verify_that, Result};
-use googletest_macro::google_test_wrapper;
-use matchers::eq;
+fn main() {}
 
-fn main() -> std::result::Result<(), ()> {
-    should_fail_in_subroutine()
-}
+#[cfg(test)]
+mod tests {
+    #[cfg(not(google3))]
+    use googletest::matchers;
+    use googletest::{google_test, verify_that, Result};
+    use matchers::eq;
 
-#[google_test_wrapper]
-fn should_fail_in_subroutine() -> Result<()> {
-    assert_that_things_are_okay(2)
-}
+    #[google_test]
+    fn should_fail_in_subroutine() -> Result<()> {
+        assert_that_things_are_okay(2)
+    }
 
-fn assert_that_things_are_okay(value: i32) -> Result<()> {
-    verify_that!(value, eq(3))
+    fn assert_that_things_are_okay(value: i32) -> Result<()> {
+        verify_that!(value, eq(3))
+    }
 }

--- a/googletest/integration_tests/custom_error_message.rs
+++ b/googletest/integration_tests/custom_error_message.rs
@@ -12,33 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(google3))]
-use googletest::matchers;
-use googletest::{verify_that, GoogleTestSupport, Result};
-use googletest_macro::google_test_wrapper;
-use matchers::eq;
+fn main() {}
 
-fn main() {
-    let _ = should_fail_with_custom_error_message();
-    let _ = should_fail_with_custom_error_message_in_string();
-    let _ = should_fail_with_custom_error_message_in_closure();
-}
+#[cfg(test)]
+mod tests {
+    #[cfg(not(google3))]
+    use googletest::matchers;
+    use googletest::{verify_that, GoogleTestSupport, Result};
+    use matchers::eq;
 
-#[google_test_wrapper]
-fn should_fail_with_custom_error_message() -> Result<()> {
-    let value = 2;
-    verify_that!(value, eq(3)).failure_message("A custom error message")
-}
+    #[test]
+    fn should_fail_with_custom_error_message() -> Result<()> {
+        let value = 2;
+        verify_that!(value, eq(3)).failure_message("A custom error message")
+    }
 
-#[google_test_wrapper]
-fn should_fail_with_custom_error_message_in_string() -> Result<()> {
-    let value = 2;
-    verify_that!(value, eq(3)).failure_message("A custom error message in a String".to_string())
-}
+    #[test]
+    fn should_fail_with_custom_error_message_in_string() -> Result<()> {
+        let value = 2;
+        verify_that!(value, eq(3)).failure_message("A custom error message in a String".to_string())
+    }
 
-#[google_test_wrapper]
-fn should_fail_with_custom_error_message_in_closure() -> Result<()> {
-    let value = 2;
-    verify_that!(value, eq(3))
-        .with_failure_message(|| "A custom error message from a closure".to_string())
+    #[test]
+    fn should_fail_with_custom_error_message_in_closure() -> Result<()> {
+        let value = 2;
+        verify_that!(value, eq(3))
+            .with_failure_message(|| "A custom error message from a closure".to_string())
+    }
 }

--- a/googletest/integration_tests/failure_due_to_fail_macro.rs
+++ b/googletest/integration_tests/failure_due_to_fail_macro.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use googletest::{fail, Result};
-use googletest_macro::google_test_wrapper;
+fn main() {}
 
-fn main() -> std::result::Result<(), ()> {
-    just_fails()
-}
+#[cfg(test)]
+mod tests {
+    use googletest::{fail, Result};
 
-#[google_test_wrapper]
-fn just_fails() -> Result<()> {
-    fail!("Expected test failure")
+    #[test]
+    fn just_fails() -> Result<()> {
+        fail!("Expected test failure")
+    }
 }

--- a/googletest/integration_tests/failure_due_to_fail_macro_with_empty_message.rs
+++ b/googletest/integration_tests/failure_due_to_fail_macro_with_empty_message.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use googletest::{fail, GoogleTestSupport};
+fn main() {}
 
-fn main() {
-    just_fails();
-}
+#[cfg(test)]
+mod tests {
+    use googletest::{fail, google_test, GoogleTestSupport, Result};
 
-fn just_fails() {
-    fail!().and_log_failure();
+    #[google_test]
+    fn just_fails() -> Result<()> {
+        fail!().and_log_failure();
+        Ok(())
+    }
 }

--- a/googletest/integration_tests/failure_due_to_fail_macro_with_format_arguments.rs
+++ b/googletest/integration_tests/failure_due_to_fail_macro_with_format_arguments.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use googletest::{fail, GoogleTestSupport};
+fn main() {}
 
-fn main() {
-    just_fails();
-}
+#[cfg(test)]
+mod tests {
+    use googletest::{fail, google_test, GoogleTestSupport, Result};
 
-fn just_fails() {
-    fail!("Failure message with argument: {}", "An argument").and_log_failure();
+    #[google_test]
+    fn just_fails() -> Result<()> {
+        fail!("Failure message with argument: {}", "An argument").and_log_failure();
+        Ok(())
+    }
 }

--- a/googletest/integration_tests/failure_due_to_returned_error.rs
+++ b/googletest/integration_tests/failure_due_to_returned_error.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use googletest_macro::google_test_wrapper;
+fn main() {}
 
-fn main() -> Result<(), ()> {
-    should_fail_due_to_returned_error()
-}
+#[cfg(test)]
+mod tests {
+    use googletest::google_test;
 
-#[google_test_wrapper]
-fn should_fail_due_to_returned_error() -> Result<(), i32> {
-    Err(123)
+    #[google_test]
+    fn should_fail_due_to_returned_error() -> Result<(), i32> {
+        Err(123)
+    }
 }

--- a/googletest/integration_tests/first_failure_aborts.rs
+++ b/googletest/integration_tests/first_failure_aborts.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(google3))]
-use googletest::matchers;
-use googletest::{verify_that, GoogleTestSupport, Result};
-use googletest_macro::google_test_wrapper;
-use matchers::eq;
+fn main() {}
 
-fn main() {
-    let _ = first_failure_aborts();
-}
+#[cfg(test)]
+mod tests {
+    #[cfg(not(google3))]
+    use googletest::matchers;
+    use googletest::{google_test, verify_that, GoogleTestSupport, Result};
+    use matchers::eq;
 
-#[google_test_wrapper]
-fn first_failure_aborts() -> Result<()> {
-    let value = 2;
-    verify_that!(value, eq(3))?;
-    verify_that!(value, eq(4)).and_log_failure();
-    Ok(())
+    #[google_test]
+    fn first_failure_aborts() -> Result<()> {
+        let value = 2;
+        verify_that!(value, eq(3))?;
+        verify_that!(value, eq(4)).and_log_failure();
+        Ok(())
+    }
 }

--- a/googletest/integration_tests/integration_tests.rs
+++ b/googletest/integration_tests/integration_tests.rs
@@ -21,10 +21,9 @@ mod tests {
     use googletest::{
         google_test, verify_pred, verify_that, GoogleTestSupport, MapErrorToTestFailure, Result,
     };
-    use googletest_macro::google_test_wrapper;
     #[cfg(google3)]
     use matchers::all;
-    use matchers::{contains_regex, contains_substring, eq, matches_regex, not};
+    use matchers::{contains_regex, contains_substring, eq, not};
     use std::process::Command;
 
     #[google_test]
@@ -110,14 +109,6 @@ Actual: 2, which isn't equal to 3
         verify_that!(status.success(), eq(false))
     }
 
-    // Using google_test_wrapper rather than google_test prevents this from being
-    // run as a real test, which would of course fail.
-    #[google_test_wrapper]
-    fn fails_but_continues() -> Result<()> {
-        verify_that!(2, eq(3)).and_log_failure();
-        Ok(())
-    }
-
     #[google_test]
     fn should_log_test_failures_to_stdout() -> Result<()> {
         let output = run_external_process_in_tests_directory("two_non_fatal_failures")?;
@@ -182,15 +173,6 @@ Actual: 2, which isn't equal to 3
 
     #[google_test]
     fn should_not_run_closure_with_custom_error_message_if_test_passes() -> Result<()> {
-        let result = should_pass_with_custom_error_message_in_closure();
-
-        verify_that!(result, eq(Ok(())))
-    }
-
-    // Using google_test_wrapper rather than google_test prevents this from being
-    // run as a real test.
-    #[google_test_wrapper]
-    fn should_pass_with_custom_error_message_in_closure() -> Result<()> {
         let value = 2;
         verify_that!(value, eq(2))
             .with_failure_message(|| panic!("This should not execute, since the assertion passes."))
@@ -198,25 +180,11 @@ Actual: 2, which isn't equal to 3
 
     #[google_test]
     fn should_verify_predicate_with_success() -> Result<()> {
-        let result = verify_predicate_with_success();
-
-        verify_that!(result, eq(Ok(())))
-    }
-
-    #[google_test_wrapper]
-    fn verify_predicate_with_success() -> Result<()> {
         verify_pred!(eq_predicate(1, 1))
     }
 
     #[google_test]
     fn should_verify_predicate_with_trailing_comma() -> Result<()> {
-        let result = verify_predicate_with_trailing_comma();
-
-        verify_that!(result, eq(Ok(())))
-    }
-
-    #[google_test_wrapper]
-    fn verify_predicate_with_trailing_comma() -> Result<()> {
         verify_pred!(eq_predicate(1, 1,))
     }
 
@@ -356,10 +324,10 @@ a_submodule :: A_STRUCT_IN_SUBMODULE.eq_predicate_as_method(a, b) was false with
 
         verify_that!(
             output,
-            matches_regex(
+            contains_regex(
                 "\
 Expected test failure
-  at .*googletest/integration_tests/failure_due_to_fail_macro.rs:[0-9]+:5
+  at .*googletest/integration_tests/failure_due_to_fail_macro.rs:[0-9]+:9
 "
             )
         )

--- a/googletest/integration_tests/non_fatal_failure_in_subroutine.rs
+++ b/googletest/integration_tests/non_fatal_failure_in_subroutine.rs
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(google3))]
-use googletest::matchers;
-use googletest::{verify_that, GoogleTestSupport, Result};
-use googletest_macro::google_test_wrapper;
-use matchers::eq;
+fn main() {}
 
-fn main() -> std::result::Result<(), ()> {
-    calls_verify_that_in_subroutine()
-}
+#[cfg(test)]
+mod tests {
+    #[cfg(not(google3))]
+    use googletest::matchers;
+    use googletest::{google_test, verify_that, GoogleTestSupport, Result};
+    use matchers::eq;
 
-#[google_test_wrapper]
-fn calls_verify_that_in_subroutine() -> Result<()> {
-    verify_that_things_are_okay(2);
-    Ok(())
-}
+    #[google_test]
+    fn calls_verify_that_in_subroutine() -> Result<()> {
+        verify_that_things_are_okay(2);
+        Ok(())
+    }
 
-fn verify_that_things_are_okay(value: i32) {
-    verify_that!(value, eq(3)).and_log_failure();
+    fn verify_that_things_are_okay(value: i32) {
+        verify_that!(value, eq(3)).and_log_failure();
+    }
 }

--- a/googletest/integration_tests/two_non_fatal_failures.rs
+++ b/googletest/integration_tests/two_non_fatal_failures.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(google3))]
-use googletest::matchers;
-use googletest::{verify_that, GoogleTestSupport, Result};
-use googletest_macro::google_test_wrapper;
-use matchers::eq;
+fn main() {}
 
-fn main() {
-    let _ = more_than_one_failure();
-}
+#[cfg(test)]
+mod tests {
+    #[cfg(not(google3))]
+    use googletest::matchers;
+    use googletest::{google_test, verify_that, GoogleTestSupport, Result};
+    use matchers::eq;
 
-#[google_test_wrapper]
-fn more_than_one_failure() -> Result<()> {
-    let value = 2;
-    verify_that!(value, eq(3)).and_log_failure();
-    verify_that!(value, eq(4)).and_log_failure();
-    Ok(())
+    #[google_test]
+    fn more_than_one_failure() -> Result<()> {
+        let value = 2;
+        verify_that!(value, eq(3)).and_log_failure();
+        verify_that!(value, eq(4)).and_log_failure();
+        Ok(())
+    }
 }

--- a/googletest/integration_tests/verify_predicate_with_failure.rs
+++ b/googletest/integration_tests/verify_predicate_with_failure.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use googletest::{verify_pred, Result};
-use googletest_macro::google_test_wrapper;
+fn main() {}
 
-fn main() -> std::result::Result<(), ()> {
-    verify_predicate_with_failure()
-}
+#[cfg(test)]
+mod tests {
+    use googletest::{google_test, verify_pred, Result};
 
-#[google_test_wrapper]
-fn verify_predicate_with_failure() -> Result<()> {
-    let a = 1;
-    let b = 2;
-    verify_pred!(eq_predicate(a, b))
-}
+    #[google_test]
+    fn verify_predicate_with_failure() -> Result<()> {
+        let a = 1;
+        let b = 2;
+        verify_pred!(eq_predicate(a, b))
+    }
 
-fn eq_predicate(a: i32, b: i32) -> bool {
-    a == b
+    fn eq_predicate(a: i32, b: i32) -> bool {
+        a == b
+    }
 }

--- a/googletest/integration_tests/verify_predicate_with_failure_as_method_in_submodule.rs
+++ b/googletest/integration_tests/verify_predicate_with_failure_as_method_in_submodule.rs
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use googletest::{verify_pred, Result};
-use googletest_macro::google_test_wrapper;
+fn main() {}
 
-fn main() {
-    let _ = verify_predicate_on_method_in_submodule_with_failure();
-}
+#[cfg(test)]
+mod tests {
+    use googletest::{google_test, verify_pred, Result};
 
-#[google_test_wrapper]
-fn verify_predicate_on_method_in_submodule_with_failure() -> Result<()> {
-    let a = 1;
-    let b = 2;
-    verify_pred!(a_submodule::A_STRUCT_IN_SUBMODULE.eq_predicate_as_method(a, b))
-}
-
-struct AStruct {}
-
-impl AStruct {
-    fn eq_predicate_as_method(&self, a: i32, b: i32) -> bool {
-        a == b
+    #[google_test]
+    fn verify_predicate_on_method_in_submodule_with_failure() -> Result<()> {
+        let a = 1;
+        let b = 2;
+        verify_pred!(a_submodule::A_STRUCT_IN_SUBMODULE.eq_predicate_as_method(a, b))
     }
-}
 
-mod a_submodule {
-    pub(super) static A_STRUCT_IN_SUBMODULE: super::AStruct = super::AStruct {};
+    struct AStruct {}
+
+    impl AStruct {
+        fn eq_predicate_as_method(&self, a: i32, b: i32) -> bool {
+            a == b
+        }
+    }
+
+    mod a_submodule {
+        pub(super) static A_STRUCT_IN_SUBMODULE: super::AStruct = super::AStruct {};
+    }
 }

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -21,7 +21,7 @@ pub mod matcher;
 #[cfg(not(google3))]
 pub mod matchers;
 
-pub use googletest_macro::{google_test, google_test_wrapper};
+pub use googletest_macro::google_test;
 
 use internal::test_outcome::TestAssertionFailure;
 

--- a/googletest_macro/src/lib.rs
+++ b/googletest_macro/src/lib.rs
@@ -54,27 +54,9 @@ pub fn google_test(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let parsed_fn = parse_macro_input!(input as ItemFn);
-    let output = quote! {
-        #[test]
-        #[googletest::google_test_wrapper]
-        #parsed_fn
-    };
-    output.into()
-}
-
-/// Wraps the given function inside an outer function which initialises and
-/// queries the `TestOutcome` for the current test.
-///
-/// This is intended to be used only by the Google Rust test library and its own
-/// tests.
-#[proc_macro_attribute]
-pub fn google_test_wrapper(
-    _args: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
-    let parsed_fn = parse_macro_input!(input as ItemFn);
     let fn_name = parsed_fn.sig.ident.clone();
     let output = quote! {
+        #[test]
         fn #fn_name() -> std::result::Result<(), ()> {
             #parsed_fn
 

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -25,8 +25,19 @@ set -e
 INTEGRATION_TEST_BINARIES=(
   "integration_tests"
   "assert_predicate_with_failure"
+  "assertion_failure_in_subroutine"
+  "custom_error_message"
+  "failure_due_to_fail_macro"
+  "failure_due_to_fail_macro_with_empty_message"
+  "failure_due_to_fail_macro_with_format_arguments"
+  "failure_due_to_returned_error"
+  "first_failure_aborts"
+  "non_fatal_failure_in_subroutine"
   "simple_assertion_failure"
   "simple_assertion_failure_with_assert_that"
+  "two_non_fatal_failures"
+  "verify_predicate_with_failure"
+  "verify_predicate_with_failure_as_method_in_submodule"
 )
 
 cargo build


### PR DESCRIPTION
This simplifies the integration tests and makes them more realistic by asserting on the actual output when the test is run by the test harness rather than faking the output by manually running the test function.

PiperOrigin-RevId: 497353368