### PR TITLE
Remove unnecessary language from code blocks

### DIFF
--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -31,7 +31,7 @@
 /// cause the test to be recorded as a failure.
 ///
 /// Example:
-/// ```rust
+/// ```
 /// value = 42;
 /// verify_that!(42, eq(42))?; // This will pass.
 /// verify_that!(42, eq(123)).and_log_failure();
@@ -62,7 +62,7 @@ macro_rules! verify_that {
 /// The failure message contains detailed information about the arguments. For
 /// example:
 ///
-/// ```rust
+/// ```
 /// fn equals_modulo(a: i32, b: i32, n: i32) -> bool { a % n == b % n }
 ///
 /// fn test() -> Result<()> {
@@ -88,7 +88,7 @@ macro_rules! verify_that {
 ///
 /// The predicate can also be a method on a struct, e.g.:
 ///
-/// ```rust
+/// ```
 /// struct AStruct {};
 ///
 /// impl AStruct {
@@ -106,7 +106,7 @@ macro_rules! verify_that {
 /// assign the outputs of non-pure functions to variables before using them in
 /// this macro. For example:
 ///
-/// ```rust
+/// ```
 /// let output = generate_random_number();  // Assigned outside of verify_pred.
 /// verify_pred!(is_sufficiently_random(output))?;
 /// ```
@@ -143,7 +143,7 @@ macro_rules! verify_pred {
 /// This can be used to force the test to fail if its execution reaches a
 /// particular point. For example:
 ///
-/// ```rust
+/// ```
 /// match some_value {
 ///     ExpectedVariant => {...}
 ///     UnwantedVaraint => {
@@ -154,7 +154,7 @@ macro_rules! verify_pred {
 ///
 /// One may include formatted arguments in the failure message:
 ///
-/// ```rust
+/// ```
 /// match some_value {
 ///     ExpectedVariant => {...}
 ///     UnwantedVaraint => {
@@ -166,7 +166,7 @@ macro_rules! verify_pred {
 /// One may also omit the message, in which case the test failure message will
 /// be generic:
 ///
-/// ```rust
+/// ```
 /// match some_value {
 ///     ExpectedVariant => {...}
 ///     UnwantedVaraint => {
@@ -251,7 +251,7 @@ macro_rules! assert_pred {
 /// Invoking this macro is equivalent to using
 /// [`and_log_failure`](crate::GoogleTestSupport::and_log_failure) as follows:
 ///
-/// ```rust
+/// ```
 /// verify_that!(actual, expected).and_log_failure()
 /// ```
 #[macro_export]
@@ -275,7 +275,7 @@ macro_rules! expect_that {
 /// Invoking this macro is equivalent to using
 /// [`and_log_failure`](crate::GoogleTestSupport::and_log_failure) as follows:
 ///
-/// ```rust
+/// ```
 /// verify_pred!(predicate(...)).and_log_failure()
 /// ```
 #[macro_export]

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -38,7 +38,7 @@
 //!
 //! For example, for fatal assertions:
 //!
-//! ```rust
+//! ```
 //! use googletest::{matchers::eq, verify_that, Result};
 //!
 //! #[test]
@@ -55,7 +55,7 @@
 //!
 //! Matchers are composable:
 //!
-//! ```rust
+//! ```
 //! use googletest::{matchers::{contains, ge}, verify_that, Result};
 //!
 //! #[test]
@@ -67,7 +67,7 @@
 //!
 //! They can also be logically combined:
 //!
-//! ```rust
+//! ```
 //! use googletest::{matchers::{gt, lt, not, AndMatcherExt}, verify_that, Result};
 //!
 //! #[test]
@@ -183,7 +183,7 @@
 //! a struct holding the matcher's data and have it implement the trait
 //! [`Matcher`]:
 //!
-//! ```rust
+//! ```
 //! struct MyEqMatcher<T> {
 //!    expected: T,
 //! }
@@ -208,7 +208,7 @@
 //!
 //! It is recommended to expose a function which constructs the matcher:
 //!
-//! ```rust
+//! ```
 //! pub fn eq_my_way<T: PartialEq + Debug>(expected: T) -> impl Matcher<T> {
 //!    MyEqMatcher { expected }
 //! }
@@ -216,7 +216,7 @@
 //!
 //! The new matcher can then be used in `verify_that!`:
 //!
-//! ```rust
+//! ```
 //! #[test]
 //! fn should_be_equal_by_my_definition() -> Result<()> {
 //!    verify_that!(10, eq_my_way(10))
@@ -234,7 +234,7 @@
 //! also be marked with [`google_test`] instead of the Rust-standard `#[test]`.
 //! It must return [`Result<()>`].
 //!
-//! ```rust
+//! ```
 //! use googletest::{
 //!    expect_that, google_test, matchers::eq, Result
 //! };
@@ -255,7 +255,7 @@
 //! predicate in a `verify_pred!` invocation to turn that into a test assertion
 //! which passes precisely when the predicate returns `true`:
 //!
-//! ```rust
+//! ```
 //! fn stuff_is_correct(x: i32, y: i32) -> bool {
 //!    x == y
 //! }
@@ -285,7 +285,7 @@
 //! [`verify_pred!`] to cause a test to fail, with an optional formatted
 //! message:
 //!
-//! ```rust
+//! ```
 //! #[test]
 //! fn always_fails() -> Result<()> {
 //!    fail!("This test must fail with {}", "today")
@@ -324,7 +324,7 @@ use internal::test_outcome::TestAssertionFailure;
 /// This can be used with subroutines which may cause the test to fatally fail
 /// and which return some value needed by the caller. For example:
 ///
-/// ```rust
+/// ```
 /// fn load_file_content_as_string() -> Result<String> {
 ///     let file_stream = load_file().err_to_test_failure()?;
 ///     Ok(file_stream.to_string())
@@ -344,7 +344,7 @@ pub trait GoogleTestSupport {
     ///
     /// This can be used for non-fatal test assertions, for example:
     ///
-    /// ```rust
+    /// ```
     /// let actual = 42;
     /// verify_that!(actual, eq(42)).and_log_failure();
     ///                                  // Test still passing; nothing happens
@@ -363,7 +363,7 @@ pub trait GoogleTestSupport {
     ///
     /// For example:
     ///
-    /// ```rust
+    /// ```
     /// let actual = 0;
     /// verify_that!(actual, eq(42)).failure_message("Actual was wrong!")?;
     /// ```
@@ -378,7 +378,7 @@ pub trait GoogleTestSupport {
     ///
     /// One can pass a `String` too:
     ///
-    /// ```rust
+    /// ```
     /// let actual = 0;
     /// verify_that!(actual, eq(42))
     ///    .failure_message(format!("Actual {} was wrong!", actual))?;
@@ -396,7 +396,7 @@ pub trait GoogleTestSupport {
     /// only executes the closure `provider` if it actually produces the
     /// message, thus saving possible memory allocation.
     ///
-    /// ```rust
+    /// ```
     /// let actual = 0;
     /// verify_that!(actual, eq(42))
     ///    .with_failure_message(|| format!("Actual {} was wrong!", actual))?;

--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -20,7 +20,7 @@
 ///
 /// For example:
 ///
-/// ```rust
+/// ```
 /// verify_that!("A string", all!(starts_with("A"), ends_width("string")))?; // Passes
 /// verify_that!("A string", all!(starts_with("A"), ends_width("not a string")))?; // Fails
 /// ```
@@ -29,7 +29,7 @@
 /// [`and`][crate::matchers::conjunction_matcher::AndMatcherExt::and] extension
 /// method:
 ///
-/// ```rust
+/// ```
 /// verify_that!("A string", starts_with("A").and(ends_width("string")))?; // Also passes
 /// ```
 ///

--- a/googletest/src/matchers/anything_matcher.rs
+++ b/googletest/src/matchers/anything_matcher.rs
@@ -22,7 +22,7 @@ use std::fmt::Debug;
 /// This is useful to check if `actual` matches the specific structure (like
 /// `Some(...)`)  but without caring about the internal value.
 ///
-/// ```rust
+/// ```
 /// let option = Some("Some value");
 /// verify_that!(option, some(anything()))?;
 /// ```

--- a/googletest/src/matchers/conjunction_matcher.rs
+++ b/googletest/src/matchers/conjunction_matcher.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 pub trait AndMatcherExt<T: Debug>: Matcher<T> {
     /// Constructs a matcher that matches both `self` and `right`.
     ///
-    /// ```rust
+    /// ```
     /// verify_that!(Struct { a: 1, b: 2 }, field!(Struct::a, eq(1)).and(field!(Struct::b, eq(2))))?;
     /// ```
     // TODO(b/264518763): Replace the return type with impl Matcher and reduce

--- a/googletest/src/matchers/container_eq_matcher.rs
+++ b/googletest/src/matchers/container_eq_matcher.rs
@@ -35,7 +35,7 @@ use std::iter::zip;
 /// implements `PartialEq`. If the container type is a `Vec`, then the expected
 /// type may be a slice of the same element type. For example:
 ///
-/// ```rust
+/// ```
 /// let vec = vec![1, 2, 3];
 /// verify_that!(vec, container_eq([1, 2, 3]))?;
 /// ```
@@ -43,7 +43,7 @@ use std::iter::zip;
 /// As an exception, if the actual type is a `Vec<String>`, the expected type
 /// may be a slice of `&str`:
 ///
-/// ```rust
+/// ```
 /// let vec: Vec<String> = vec!["A string".into(), "Another string".into()];
 /// verify_that!(vec, container_eq(["A string", "Another string"]))?;
 /// ```
@@ -54,7 +54,7 @@ use std::iter::zip;
 /// One can also check container equality of a slice with an array. To do so,
 /// dereference the slice:
 ///
-/// ```rust
+/// ```
 /// let value = &[1, 2, 3];
 /// verify_that!(*value, container_eq([1, 2, 3]))?;
 /// ```

--- a/googletest/src/matchers/contains_matcher.rs
+++ b/googletest/src/matchers/contains_matcher.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 /// by `inner`. Use the method [`ContainsMatcher::times`] to constrain the
 /// matched containers to a specific number of matching elements.
 ///
-/// ```rust
+/// ```
 /// verify_that!(["Some value"], contains(eq("Some value")))?;  // Passes
 /// verify_that!(vec!["Some value"], contains(eq("Some value")))?;  // Passes
 /// verify_that!([], contains(eq("Some value")))?;   // Fails

--- a/googletest/src/matchers/contains_regex_matcher.rs
+++ b/googletest/src/matchers/contains_regex_matcher.rs
@@ -25,7 +25,7 @@ use std::ops::Deref;
 /// Both the actual value and the expected regular expression may be either a
 /// `String` or a string reference.
 ///
-/// ```rust
+/// ```
 /// verify_that!("Some value", contains_regex("S.*e"))?;  // Passes
 /// verify_that!("Another value", contains_regex("Some"))?;   // Fails
 /// verify_that!("Some value".to_string(), contains_regex("v.*e"))?;   // Passes

--- a/googletest/src/matchers/disjunction_matcher.rs
+++ b/googletest/src/matchers/disjunction_matcher.rs
@@ -22,7 +22,7 @@ pub trait OrMatcherExt<T: Debug>: Matcher<T> {
     /// Constructs a matcher that matches when at least one of `self` or `right`
     /// matches the input.
     ///
-    /// ```rust
+    /// ```
     /// verify_that!(10, eq(2).or(ge(5)))?;  // Passes
     /// verify_that!(10, eq(2).or(eq(5)).or(ge(9)))?;  // Passes
     /// verify_that!(10, eq(2).or(ge(15)))?; // Fails

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -21,7 +21,7 @@ use std::marker::PhantomData;
 /// Matches the string representation of types that implement `Display`.
 ///
 ///
-/// ```rust
+/// ```
 /// let result: impl Display = ...;
 /// verify_that!(result, displays_as(eq(format!("{}", result))))?;
 /// ```

--- a/googletest/src/matchers/each_matcher.rs
+++ b/googletest/src/matchers/each_matcher.rs
@@ -22,7 +22,7 @@ use std::fmt::Debug;
 ///
 /// `T` can be any container such that `&T` implements `IntoIterator`.
 ///
-/// ```rust
+/// ```
 /// let value: Vec<i32> = vec![1, 2, 3];
 /// verify_that!(value, each(gt(0)))?;  // Passes
 /// verify_that!(value, each(lt(2)))?;  // Fails: 2 and 3 are not less than 2
@@ -33,7 +33,7 @@ use std::fmt::Debug;
 ///
 /// One can also verify the contents of a slice by dereferencing it:
 ///
-/// ```rust
+/// ```
 /// let value = &[1, 2, 3];
 /// verify_that!(*value, each(gt(0)))?;
 /// ```

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -18,7 +18,7 @@
 
 /// Matches a container's elements to each matcher in order.
 ///
-/// ```rust
+/// ```
 /// verify_that!(vec![1,2,3], elements_are![eq(1), anything(), gt(0).and(lt(123))])
 /// ```
 ///

--- a/googletest/src/matchers/empty_matcher.rs
+++ b/googletest/src/matchers/empty_matcher.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 ///
 /// `T` can be any container such that `&T` implements `IntoIterator`.
 ///
-/// ```rust
+/// ```
 /// let value: Vec<i32> = vec![];
 /// verify_that!(value, empty())?;
 /// let value: HashSet<i32> = HashSet::new();
@@ -30,7 +30,7 @@ use std::fmt::Debug;
 ///
 /// One can also check whether a slice is empty by dereferencing it:
 ///
-/// ```rust
+/// ```
 /// let value = &[];
 /// verify_that!(*value, empty())?;
 /// ```

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -22,7 +22,7 @@ use std::fmt::Debug;
 /// The type of `expected` must implement the [`PartialEq`] trait so that the
 /// expected and actual values can be compared.
 ///
-/// ```rust
+/// ```
 /// verify_that!(123, eq(123))?; // Passes
 /// verify_that!(123, eq(234))?; // Fails
 /// ```
@@ -32,19 +32,19 @@ use std::fmt::Debug;
 /// type. However, there are a few cases where different but closely related
 /// types are comparable, for example `String` with `&str`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(String::new("Some value"), eq("Some value"))?; // Passes
 /// ```
 ///
 /// In most cases however, one must convert one of the arguments explicitly.
 /// This can be surprising when comparing integer types or references.
 ///
-/// ```rust
+/// ```
 /// verify_that!(123u32, eq(123u64))?; // Does not compile
 /// verify_that!(123u32 as u64, eq(123u64))?; // Passes
 /// ```
 ///
-/// ```rust
+/// ```
 /// let actual: &T = ...;
 /// let expected: T = T{...};
 /// verify_that(actual, eq(expected))?; // Does not compile

--- a/googletest/src/matchers/err_matcher.rs
+++ b/googletest/src/matchers/err_matcher.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 
 /// Matches a `Result` containing `Err` with a value matched by `inner`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(Err("Some error"), err(eq("Some error")))?;  // Passes
 /// verify_that!(Ok("A value"), err(eq("A value")))?;   // Fails
 /// verify_that!(Err("Some error"), err(eq("Some error value")))?;   // Fails

--- a/googletest/src/matchers/field_matcher.rs
+++ b/googletest/src/matchers/field_matcher.rs
@@ -21,7 +21,7 @@
 ///
 /// For example:
 ///
-/// ```rust
+/// ```
 /// struct IntField {
 ///   int: i32
 /// }
@@ -30,7 +30,7 @@
 ///
 /// Tuple structs are also supported via the index syntax:
 ///
-/// ```rust
+/// ```
 /// struct IntField(i32)
 /// verify_that!(IntField(32), field!(IntField.0, eq(32)))?;
 /// ```
@@ -38,7 +38,7 @@
 /// Enums are also supported, in which case only the specified variant is
 /// matched:
 ///
-/// ```rust
+/// ```
 /// enum MyEnum {
 ///     A(i32),
 ///     B,
@@ -49,7 +49,7 @@
 ///
 /// The structure or enum may also be referenced from a separate module:
 ///
-/// ```rust
+/// ```
 /// mod a_module {
 ///     struct AStruct(i32);
 /// }
@@ -58,7 +58,7 @@
 ///
 /// Nested structures are *not supported*, however:
 ///
-/// ```rust
+/// ```
 /// struct InnerStruct(i32);
 /// struct OuterStruct {
 ///     inner: InnerStruct,

--- a/googletest/src/matchers/ge_matcher.rs
+++ b/googletest/src/matchers/ge_matcher.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 /// comparable via the `PartialOrd` trait. Namely, `ActualT` must implement
 /// `PartialOrd<ExpectedT>`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(1, ge(0))?; // Passes
 /// verify_that!(0, ge(1))?; // Fails
 /// ```
@@ -32,12 +32,12 @@ use std::fmt::Debug;
 /// explicitly. This can be surprising when comparing integer types or
 /// references:
 ///
-/// ```rust
+/// ```
 /// verify_that!(123u32, ge(0u64))?; // Does not compile
 /// verify_that!(123u32 as u64, ge(0u64))?; // Passes
 /// ```
 ///
-/// ```rust
+/// ```
 /// let actual: &u32 = &2;
 /// let expected: u32 = 0;
 /// verify_that(actual, ge(expected))?; // Does not compile

--- a/googletest/src/matchers/gt_matcher.rs
+++ b/googletest/src/matchers/gt_matcher.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 /// comparable via the `PartialOrd` trait. Namely, `ActualT` must implement
 /// `PartialOrd<ExpectedT>`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(38, gt(1))?; // Passes
 /// verify_that!(234, gt(234))?; // Fails
 /// ```
@@ -32,12 +32,12 @@ use std::fmt::Debug;
 /// explicitly. This can be surprising when comparing integer types or
 /// references:
 ///
-/// ```rust
+/// ```
 /// verify_that!(123u32, gt(0u64))?; // Does not compile
 /// verify_that!(123u32 as u64, gt(0u64))?; // Passes
 /// ```
 ///
-/// ```rust
+/// ```
 /// let actual: &u32 = &2;
 /// let expected: u32 = 1;
 /// verify_that(actual, gt(expected))?; // Does not compile

--- a/googletest/src/matchers/has_entry_matcher.rs
+++ b/googletest/src/matchers/has_entry_matcher.rs
@@ -22,7 +22,7 @@ use std::hash::Hash;
 /// Matches a HashMap containing the given `key` whose value is matched by the
 /// matcher `inner`.
 ///
-/// ```rust
+/// ```
 /// let value: HashMap<i32, i32> = HashMap::from([(0, 1), (1, -1)]);
 /// verify_that!(value, has_entry(0, eq(1)))?;  // Passes
 /// verify_that!(value, has_entry(1, gt(0)))?;  // Fails: value not matched
@@ -32,7 +32,7 @@ use std::hash::Hash;
 /// Note: One could obtain the same effect by collecting entries into a `Vec`
 /// and using `contains`:
 ///
-/// ```rust
+/// ```
 /// let value: HashMap<i32, i32> = HashMap::from([(0, 1), (1, -1)]);
 /// verify_that!(value.into_iter().collect::<Vec<_>>(), contains(eq((0, 1))))?;
 /// ```

--- a/googletest/src/matchers/le_matcher.rs
+++ b/googletest/src/matchers/le_matcher.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 /// comparable via the `PartialOrd` trait. Namely, `ActualT` must implement
 /// `PartialOrd<ExpectedT>`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(0, le(0))?; // Passes
 /// verify_that!(1, le(0))?; // Fails
 /// ```
@@ -32,12 +32,12 @@ use std::fmt::Debug;
 /// explicitly. This can be surprising when comparing integer types or
 /// references:
 ///
-/// ```rust
+/// ```
 /// verify_that!(1u32, le(2u64))?; // Does not compile
 /// verify_that!(1u32 as u64, le(2u64))?; // Passes
 /// ```
 ///
-/// ```rust
+/// ```
 /// let actual: &u32 = &1;
 /// let expected: u32 = 2;
 /// verify_that(actual, le(expected))?; // Does not compile

--- a/googletest/src/matchers/lt_matcher.rs
+++ b/googletest/src/matchers/lt_matcher.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 /// comparable via the `PartialOrd` trait. Namely, `ActualT` must implement
 /// `PartialOrd<ExpectedT>`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(1, lt(2))?; // Passes
 /// verify_that!(2, lt(2))?; // Fails
 /// ```
@@ -32,12 +32,12 @@ use std::fmt::Debug;
 /// explicitly. This can be surprising when comparing integer types or
 /// references:
 ///
-/// ```rust
+/// ```
 /// verify_that!(123u32, lt(0u64))?; // Does not compile
 /// verify_that!(123u32 as u64, lt(100000000u64))?; // Passes
 /// ```
 ///
-/// ```rust
+/// ```
 /// let actual: &u32 = &2;
 /// let expected: u32 = 70;
 /// verify_that(actual, lt(expected))?; // Does not compile

--- a/googletest/src/matchers/matches_pattern.rs
+++ b/googletest/src/matchers/matches_pattern.rs
@@ -21,7 +21,7 @@
 /// This can be used to match arbitrary combinations of fields on structures
 /// using arbitrary matchers:
 ///
-/// ```rust
+/// ```
 /// struct MyStruct {
 ///     a_field: String,
 ///     another_field: String,
@@ -35,7 +35,7 @@
 ///
 /// One can use it recursively to match nested structures:
 ///
-/// ```rust
+/// ```
 /// struct MyStruct {
 ///     a_nested_struct: MyInnerStruct,
 /// }
@@ -53,7 +53,7 @@
 ///
 /// One can use the alias [`pat`][crate::pat] to make this less verbose:
 ///
-/// ```rust
+/// ```
 /// verify_that!(my_struct, matches_pattern!(MyStruct {
 ///     a_nested_struct: pat!(MyInnerStruct {
 ///         a_field: starts_with("Something"),
@@ -64,7 +64,7 @@
 /// One can also match tuple structs with up to 10 fields. In this case, all
 /// fields must have matchers:
 ///
-/// ```rust
+/// ```
 /// struct MyTupleStruct(String, String);
 ///
 /// verify_that!(
@@ -75,7 +75,7 @@
 ///
 /// One can also match enum values:
 ///
-/// ```rust
+/// ```
 /// enum MyEnum {
 ///     A(u32),
 ///     B,

--- a/googletest/src/matchers/matches_regex_matcher.rs
+++ b/googletest/src/matchers/matches_regex_matcher.rs
@@ -28,7 +28,7 @@ use std::ops::Deref;
 /// Both the actual value and the expected regular expression may be either a
 /// `String` or a string reference.
 ///
-/// ```rust
+/// ```
 /// verify_that!("Some value", matches_regex("S.*e"))?;  // Passes
 /// verify_that!("Another value", matches_regex("Some"))?;   // Fails
 /// verify_that!("Some value", matches_regex("Some"))?;   // Fails

--- a/googletest/src/matchers/near_matcher.rs
+++ b/googletest/src/matchers/near_matcher.rs
@@ -27,7 +27,7 @@ use std::fmt::Debug;
 /// `max_abs_error` must be non-negative. The matcher panics on construction
 /// otherwise.
 ///
-/// ```rust
+/// ```
 /// verify_that!(1.0, near(1.0, 0.1))?; // Passes
 /// verify_that!(1.01, near(1.0, 0.1))?; // Passes
 /// verify_that!(1.25, near(1.0, 0.25))?; // Passes
@@ -41,7 +41,7 @@ use std::fmt::Debug;
 /// floating point standard. Thus infinity is infinitely far away from any
 /// floating point value:
 ///
-/// ```rust
+/// ```
 /// verify_that!(f64::INFINITY, near(0.0, f64::MAX))?; // Fails
 /// verify_that!(0.0, near(f64::INFINITY, f64::MAX))?; // Fails
 /// verify_that!(f64::INFINITY, near(f64::INFINITY, f64::MAX))?; // Fails
@@ -49,7 +49,7 @@ use std::fmt::Debug;
 ///
 /// Similarly, by default, `NaN` is infinitely far away from any value:
 ///
-/// ```rust
+/// ```
 /// verify_that!(f64::NAN, near(0.0, f64::MAX))?; // Fails
 /// verify_that!(0.0, near(f64::NAN, f64::MAX))?; // Fails
 /// verify_that!(f64::NAN, near(f64::NAN, f64::MAX))?; // Fails
@@ -58,7 +58,7 @@ use std::fmt::Debug;
 /// To treat two `NaN` values as equal, use the method
 /// [`NearMatcher::nans_are_equal`].
 ///
-/// ```rust
+/// ```
 /// verify_that!(f64::NAN, near(f64::NAN, f64::MAX).nans_are_equal())?; // Passes
 /// ```
 pub fn near<T: Debug + Float + Copy>(expected: T, max_abs_error: T) -> NearMatcher<T> {

--- a/googletest/src/matchers/none_matcher.rs
+++ b/googletest/src/matchers/none_matcher.rs
@@ -20,7 +20,7 @@ use std::marker::PhantomData;
 
 /// Matches an `Option` containing `None`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(None, none())?;   // Passes
 /// verify_that!(Some("Some value"), none())?;  // Fails
 /// ```

--- a/googletest/src/matchers/not_matcher.rs
+++ b/googletest/src/matchers/not_matcher.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 
 /// Matches the actual value exactly when the inner matcher does _not_ match.
 ///
-/// ```rust
+/// ```
 /// verify_that!(0, not(eq(1)))?; // Passes
 /// verify_that!(0, not(eq(0)))?; // Fails
 /// ```

--- a/googletest/src/matchers/ok_matcher.rs
+++ b/googletest/src/matchers/ok_matcher.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 
 /// Matches a `Result` containing `Ok` with a value matched by `inner`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(Ok("Some value"), ok(eq("Some value")))?;  // Passes
 /// verify_that!(Err("An error"), ok(eq("An error")))?;   // Fails
 /// verify_that!(Ok("Some value"), ok(eq("Some other value")))?;   // Fails

--- a/googletest/src/matchers/points_to_matcher.rs
+++ b/googletest/src/matchers/points_to_matcher.rs
@@ -24,7 +24,7 @@ use std::ops::Deref;
 /// This allows easily matching smart pointers such as `Box`, `Rc`, and `Arc`.
 /// For example:
 ///
-/// ```rust
+/// ```
 /// verify_that!(Box::new(123), points_to(eq(123)))?;
 /// ```
 pub fn points_to<ExpectedT, MatcherT, ActualT>(expected: MatcherT) -> impl Matcher<ActualT>

--- a/googletest/src/matchers/pointwise_matcher.rs
+++ b/googletest/src/matchers/pointwise_matcher.rs
@@ -23,7 +23,7 @@
 /// For example, the following matches a container of integers each of which
 /// does not exceed the given upper bounds:
 ///
-/// ```rust
+/// ```
 /// let value = vec![1, 2, 3];
 /// verify_that!(value, pointwise!(le, [1, 3, 3]))?; // Passes
 /// verify_that!(value, pointwise!(le, [1, 1, 3]))?; // Fails

--- a/googletest/src/matchers/predicate_matcher.rs
+++ b/googletest/src/matchers/predicate_matcher.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 
 /// Creates a matcher based on the predicate provided.
 ///
-/// ```rust
+/// ```
 /// verify_that!(3, predicate(|x: &i32| x % 2 == 1))?;  // Passes
 /// ```
 ///
@@ -48,7 +48,7 @@ impl<P> PredicateMatcher<P, NoDescription, NoDescription> {
     ///
     /// For example, to make sure the error message is more useful
     ///
-    /// ```rust
+    /// ```
     /// predicate(|x: &i32| x % 2 == 1)
     ///   .with_description("is odd", "is even")
     /// ```

--- a/googletest/src/matchers/size_matcher.rs
+++ b/googletest/src/matchers/size_matcher.rs
@@ -26,7 +26,7 @@ use std::fmt::Debug;
 /// `T` must be a container and implement the [`HasSize`] trait so that the size
 /// can be extracted.
 ///
-/// ```rust
+/// ```
 /// let value = vec![1,2,3];
 /// verify_that!(value, size(eq(3)))?;
 /// ```

--- a/googletest/src/matchers/some_matcher.rs
+++ b/googletest/src/matchers/some_matcher.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 
 /// Matches an `Option` containing a value matched by `inner`.
 ///
-/// ```rust
+/// ```
 /// verify_that!(Some("Some value"), some(eq("Some value")))?;  // Passes
 /// verify_that!(None, some(eq("Some value")))?;   // Fails
 /// verify_that!(Some("Some value"), some(eq("Some other value")))?;   // Fails

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -26,7 +26,7 @@ use std::ops::Deref;
 /// Both the actual value and the expected substring may be either a `String` or
 /// a string reference.
 ///
-/// ```rust
+/// ```
 /// verify_that!("Some value", contains_substring("Some"))?;  // Passes
 /// verify_that!("Another value", contains_substring("Some"))?;   // Fails
 /// verify_that!("Some value".to_string(), contains_substring("value"))?;   // Passes
@@ -50,7 +50,7 @@ pub fn contains_substring<T>(expected: T) -> StrMatcher<T> {
 /// Both the actual value and the expected prefix may be either a `String` or
 /// a string reference.
 ///
-/// ```rust
+/// ```
 /// verify_that!("Some value", starts_with("Some"))?;  // Passes
 /// verify_that!("Another value", starts_with("Some"))?;   // Fails
 /// verify_that!("Some value", starts_with("value"))?;  // Fails
@@ -69,7 +69,7 @@ pub fn starts_with<T>(expected: T) -> StrMatcher<T> {
 /// Both the actual value and the expected suffix may be either a `String` or
 /// a string reference.
 ///
-/// ```rust
+/// ```
 /// verify_that!("Some value", ends_with("value"))?;  // Passes
 /// verify_that!("Some value", ends_with("other value"))?;   // Fails
 /// verify_that!("Some value", ends_with("Some"))?;  // Fails
@@ -94,7 +94,7 @@ pub trait StrMatcherConfigurator<T> {
     ///
     /// Whitespace is defined as in [`str::trim_start`].
     ///
-    /// ```rust
+    /// ```
     /// verify_that!("A string", eq("   A string").ignoring_leading_whitespace())?; // Passes
     /// verify_that!("   A string", eq("A string").ignoring_leading_whitespace())?; // Passes
     /// ```
@@ -111,7 +111,7 @@ pub trait StrMatcherConfigurator<T> {
     ///
     /// Whitespace is defined as in [`str::trim_end`].
     ///
-    /// ```rust
+    /// ```
     /// verify_that!("A string", eq("A string   ").ignoring_trailing_whitespace())?; // Passes
     /// verify_that!("A string   ", eq("A string").ignoring_trailing_whitespace())?; // Passes
     /// ```
@@ -128,7 +128,7 @@ pub trait StrMatcherConfigurator<T> {
     ///
     /// Whitespace is defined as in [`str::trim`].
     ///
-    /// ```rust
+    /// ```
     /// verify_that!("A string", eq("   A string   ").ignoring_outer_whitespace())?; // Passes
     /// verify_that!("   A string   ", eq("A string").ignoring_outer_whitespace())?; // Passes
     /// ```
@@ -148,7 +148,7 @@ pub trait StrMatcherConfigurator<T> {
     ///
     /// This uses the same rules for case as [`str::eq_ignore_ascii_case`].
     ///
-    /// ```rust
+    /// ```
     /// verify_that!("Some value", eq_ignoring_ascii_case("SOME VALUE"))?;  // Passes
     /// verify_that!("Another value", eq_ignoring_ascii_case("Some value"))?;   // Fails
     /// ```

--- a/googletest/src/matchers/subset_of_matcher.rs
+++ b/googletest/src/matchers/subset_of_matcher.rs
@@ -26,7 +26,7 @@ use std::fmt::Debug;
 /// `ActualT` and `ExpectedT` can each be any container a reference to which
 /// implements `IntoIterator`. They need not be the same container type.
 ///
-/// ```rust
+/// ```
 /// let value: Vec<i32> = vec![1, 2, 3];
 /// verify_that!(value, subset_of([1, 2, 3, 4]))?;  // Passes
 /// verify_that!(value, subset_of([1, 2]))?;  // Fails: 3 is not in the superset
@@ -37,7 +37,7 @@ use std::fmt::Debug;
 ///
 /// Item multiplicity in both the actual and expected containers is ignored:
 ///
-/// ```rust
+/// ```
 /// let value: Vec<i32> = vec![0, 0, 1];
 /// verify_that!(value, subset_of([0, 1]))?;  // Passes
 /// verify_that!(value, subset_of([0, 1, 1]))?;  // Passes
@@ -45,7 +45,7 @@ use std::fmt::Debug;
 ///
 /// One can also verify the contents of a slice by dereferencing it:
 ///
-/// ```rust
+/// ```
 /// let value = &[1, 2, 3];
 /// verify_that!(*value, subset_of([1, 2, 3]))?;
 /// ```

--- a/googletest/src/matchers/superset_of_matcher.rs
+++ b/googletest/src/matchers/superset_of_matcher.rs
@@ -26,7 +26,7 @@ use std::fmt::Debug;
 /// `ActualT` and `ExpectedT` can each be any container a reference to which
 /// implements `IntoIterator`. They need not be the same container type.
 ///
-/// ```rust
+/// ```
 /// let value: Vec<i32> = vec![1, 2, 3];
 /// verify_that!(value, superset_of([1, 2]))?;  // Passes
 /// verify_that!(value, superset_of([1, 2, 4]))?;  // Fails: 4 is not in the subset
@@ -37,7 +37,7 @@ use std::fmt::Debug;
 ///
 /// Item multiplicity in both the actual and expected containers is ignored:
 ///
-/// ```rust
+/// ```
 /// let value: Vec<i32> = vec![0, 0, 1];
 /// verify_that!(value, superset_of([0, 1]))?;  // Passes
 /// verify_that!(value, superset_of([0, 1, 1]))?;  // Passes
@@ -45,7 +45,7 @@ use std::fmt::Debug;
 ///
 /// One can also verify the contents of a slice by dereferencing it:
 ///
-/// ```rust
+/// ```
 /// let value = &[1, 2, 3];
 /// verify_that!(*value, superset_of([1, 2, 3]))?;
 /// ```

--- a/googletest/src/matchers/tuple_matcher.rs
+++ b/googletest/src/matchers/tuple_matcher.rs
@@ -18,7 +18,7 @@
 
 /// Matches a tuple whose elements are matched by each of the given matchers.
 ///
-/// ```rust
+/// ```
 /// verify_that((123, 456), tuple!(eq(123), eq(456)))?; // Passes
 /// verify_that((123, 456), tuple!(eq(123), eq(0)))?; // Fails: second matcher does not match
 /// ```
@@ -26,7 +26,7 @@
 /// Matchers must correspond to the actual tuple in count and type. Otherwise
 /// the test will fail to compile.
 ///
-/// ```rust
+/// ```
 /// verify_that((123, 456), tuple!(eq(123)))?; // Does not compile: wrong tuple size
 /// verify_that((123, "A string"), tuple!(eq(123), eq(456)))?; // Does not compile: wrong type
 /// ```
@@ -35,7 +35,7 @@
 /// [`anything`][crate::matchers::anything] for fields which are not relevant
 /// for the test.
 ///
-/// ```rust
+/// ```
 /// verify_that((123, 456), tuple!(eq(123), anything()))
 /// ```
 ///

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -19,7 +19,7 @@
 /// Matches a container whose elements in any order have a 1:1 correspondence
 /// with the provided element matchers.
 ///
-/// ```rust
+/// ```
 /// verify_that!(vec![3, 2, 1], unordered_elements_are![eq(1), ge(2), anything()])?;   // Passes
 /// verify_that!(vec![1], unordered_elements_are![eq(1), ge(2)])?;              // Fails: container has wrong size
 /// verify_that!(vec![3, 2, 1], unordered_elements_are![eq(1), ge(4), eq(2)])?; // Fails: second matcher not matched
@@ -65,7 +65,7 @@ macro_rules! unordered_elements_are {
 /// Put another way, `contains_each!` matches if there is a subset of the actual
 /// container which [`unordered_elements_are`] would match.
 ///
-/// ```rust
+/// ```
 /// verify_that!(vec![3, 2, 1], contains_each![eq(2), ge(3)])?;   // Passes
 /// verify_that!(vec![3, 2, 1], contains_each![ge(3), ge(3)])?;   // Passes
 /// verify_that!(vec![1], contains_each![eq(1), ge(2)])?;         // Fails: container too small
@@ -110,7 +110,7 @@ macro_rules! contains_each {
 /// Put another way, `is_contained_in!` matches if there is a subset of the
 /// matchers which would match with [`unordered_elements_are`].
 ///
-/// ```rust
+/// ```
 /// verify_that!(vec![2, 1], is_contained_in![eq(1), ge(2)])?;   // Passes
 /// verify_that!(vec![2, 1], is_contained_in![ge(1), ge(1)])?;   // Passes
 /// verify_that!(vec![1, 2, 3], is_contained_in![eq(1), ge(2)])?; // Fails: container too large

--- a/googletest_macro/src/lib.rs
+++ b/googletest_macro/src/lib.rs
@@ -19,7 +19,7 @@ use syn::{parse_macro_input, ItemFn};
 ///
 /// Annotate tests the same way ordinary Rust tests are annotated:
 ///
-/// ```rust
+/// ```
 /// #[google_test]
 /// fn should_work() -> GoogleTestResult {
 ///     ...
@@ -35,7 +35,7 @@ use syn::{parse_macro_input, ItemFn};
 /// be invoked with the `?` operator so that a failure in the subroutine aborts
 /// the rest of the test execution:
 ///
-/// ```rust
+/// ```
 /// #[google_test]
 /// fn should_work() -> GoogleTestResult {
 ///     ...


### PR DESCRIPTION
Rust is the default language for fenced code blocks in [doc comments][1].

I left the code blocks in the README alone since they'll also be displayed by other systems (such as GitHub) which don't default to Rust.

[1]: https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html