### PR TITLE
Fix the matches_pattern! macro.

### DIFF
--- a/googletest/src/matchers/matches_pattern.rs
+++ b/googletest/src/matchers/matches_pattern.rs
@@ -132,7 +132,7 @@ macro_rules! matches_pattern_internal {
         [$($struct_name:tt)*],
         { $field_name:ident : $matcher:expr, $($rest:tt)* }
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(field!($($struct_name)*.$field_name, $matcher)),
             [$($struct_name)*],
             { $($rest)* }
@@ -155,7 +155,7 @@ macro_rules! matches_pattern_internal {
         [$($struct_name:tt)*],
         { $field_name:ident : $matcher:expr, $($rest:tt)* }
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.$field_name, $matcher)
@@ -187,7 +187,7 @@ macro_rules! matches_pattern_internal {
         [$($struct_name:tt)*],
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 field!($($struct_name)*.0, $matcher)
             ),
@@ -218,7 +218,7 @@ macro_rules! matches_pattern_internal {
         1,
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.1, $matcher)
@@ -235,7 +235,7 @@ macro_rules! matches_pattern_internal {
         2,
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.2, $matcher)
@@ -252,7 +252,7 @@ macro_rules! matches_pattern_internal {
         3,
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.3, $matcher)
@@ -269,7 +269,7 @@ macro_rules! matches_pattern_internal {
         4,
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.4, $matcher)
@@ -286,7 +286,7 @@ macro_rules! matches_pattern_internal {
         5,
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.5, $matcher)
@@ -303,7 +303,7 @@ macro_rules! matches_pattern_internal {
         6,
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.6, $matcher)
@@ -320,7 +320,7 @@ macro_rules! matches_pattern_internal {
         7,
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.7, $matcher)
@@ -337,7 +337,7 @@ macro_rules! matches_pattern_internal {
         8,
         ($matcher:expr, $($rest:tt)*)
     ) => {
-        matches_pattern_internal!(
+        $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
                 field!($($struct_name)*.8, $matcher)
@@ -349,7 +349,7 @@ macro_rules! matches_pattern_internal {
     };
 
     ([$($struct_name:tt)*], $first:tt $($rest:tt)*) => {
-        matches_pattern_internal!([$($struct_name)* $first], $($rest)*)
+        $crate::matches_pattern_internal!([$($struct_name)* $first], $($rest)*)
     };
 
     ($first:tt $($rest:tt)*) => {{
@@ -362,14 +362,14 @@ macro_rules! matches_pattern_internal {
         #[cfg(google3)]
         #[allow(unused)]
         use field_matcher::field;
-        matches_pattern_internal!([$first], $($rest)*)
+        $crate::matches_pattern_internal!([$first], $($rest)*)
     }};
 }
 
 /// An alias for [`matches_pattern`].
 #[macro_export]
 macro_rules! pat {
-    ($($t:tt)*) => { matches_pattern_internal!($($t)*) }
+    ($($t:tt)*) => { $crate::matches_pattern_internal!($($t)*) }
 }
 
 #[cfg(test)]

--- a/googletest/tests/lib.rs
+++ b/googletest/tests/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod matches_pattern_test;

--- a/googletest/tests/matches_pattern_test.rs
+++ b/googletest/tests/matches_pattern_test.rs
@@ -1,0 +1,415 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(google3))]
+use googletest::matchers;
+use googletest::{google_test, matches_pattern, pat, verify_that, Result};
+use indoc::indoc;
+use matchers::{contains_substring, displays_as, eq, err, not};
+
+#[google_test]
+fn matches_struct_containing_single_field() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_field: u32,
+    }
+    let actual = AStruct { a_field: 123 };
+
+    verify_that!(actual, matches_pattern!(AStruct { a_field: eq(123) }))
+}
+
+#[google_test]
+fn matches_struct_containing_two_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_field: u32,
+        another_field: u32,
+    }
+    let actual = AStruct {
+        a_field: 123,
+        another_field: 234,
+    };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            a_field: eq(123),
+            another_field: eq(234)
+        })
+    )
+}
+
+#[google_test]
+#[rustfmt::skip]// Otherwise fmt strips the trailing comma
+fn supports_trailing_comma_with_one_field() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_field: u32,
+    }
+    let actual = AStruct { a_field: 123 };
+
+    verify_that!(actual, matches_pattern!(AStruct {
+        a_field: eq(123), // Block reformatting
+    }))
+}
+
+#[google_test]
+fn supports_trailing_comma_with_two_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_field: u32,
+        another_field: u32,
+    }
+    let actual = AStruct {
+        a_field: 123,
+        another_field: 234,
+    };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            a_field: eq(123),
+            another_field: eq(234), // Block reformatting
+        })
+    )
+}
+
+#[google_test]
+fn supports_trailing_comma_with_three_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_field: u32,
+        another_field: u32,
+        a_third_field: u32,
+    }
+    let actual = AStruct {
+        a_field: 123,
+        another_field: 234,
+        a_third_field: 345,
+    };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            a_field: eq(123),
+            another_field: eq(234),
+            a_third_field: eq(345),
+        })
+    )
+}
+
+#[google_test]
+fn matches_struct_containing_nested_struct_with_field() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_nested_struct: ANestedStruct,
+    }
+    #[derive(Debug)]
+    struct ANestedStruct {
+        a_field: u32,
+    }
+    let actual = AStruct {
+        a_nested_struct: ANestedStruct { a_field: 123 },
+    };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            a_nested_struct: pat!(ANestedStruct { a_field: eq(123) })
+        })
+    )
+}
+
+#[google_test]
+fn has_correct_assertion_failure_message_for_single_field() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_field: u32,
+    }
+    let actual = AStruct { a_field: 123 };
+    let result = verify_that!(actual, matches_pattern!(AStruct { a_field: eq(234) }));
+
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc! {"
+            Value of: actual
+            Expected: has field `a_field`, which is equal to 234
+            Actual: AStruct {
+                a_field: 123,
+            }, which has field `a_field`, which isn't equal to 234
+            "
+        })))
+    )
+}
+
+#[google_test]
+fn has_correct_assertion_failure_message_for_two_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_field: u32,
+        another_field: u32,
+    }
+    let actual = AStruct {
+        a_field: 123,
+        another_field: 234,
+    };
+    let result = verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            a_field: eq(234),
+            another_field: eq(123)
+        })
+    );
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc!(
+            "
+            Value of: actual
+            Expected: has all the following properties:
+              * has field `a_field`, which is equal to 234
+              * has field `another_field`, which is equal to 123
+            Actual: AStruct {
+                a_field: 123,
+                another_field: 234,
+            }, 
+              * which has field `a_field`, which isn't equal to 234
+              * which has field `another_field`, which isn't equal to 123"
+        ))))
+    )
+}
+
+#[google_test]
+fn supports_qualified_struct_names() -> Result<()> {
+    mod a_module {
+        #[derive(Debug)]
+        pub(super) struct AStruct {
+            pub(super) a_field: u32,
+        }
+    }
+    let actual = a_module::AStruct { a_field: 123 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(a_module::AStruct { a_field: eq(123) })
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_single_field() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32);
+    let actual = AStruct(123);
+
+    verify_that!(actual, matches_pattern!(AStruct(eq(123))))
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_two_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32);
+    let actual = AStruct(123, 234);
+
+    verify_that!(actual, matches_pattern!(AStruct(eq(123), eq(234))))
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_three_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32, u32);
+    let actual = AStruct(123, 234, 345);
+
+    verify_that!(actual, matches_pattern!(AStruct(eq(123), eq(234), eq(345))))
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_four_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32, u32, u32);
+    let actual = AStruct(123, 234, 345, 456);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(eq(123), eq(234), eq(345), eq(456)))
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_five_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32, u32, u32, u32);
+    let actual = AStruct(123, 234, 345, 456, 567);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(eq(123), eq(234), eq(345), eq(456), eq(567)))
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_six_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32, u32, u32, u32, u32);
+    let actual = AStruct(123, 234, 345, 456, 567, 678);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(
+            eq(123),
+            eq(234),
+            eq(345),
+            eq(456),
+            eq(567),
+            eq(678)
+        ))
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_seven_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32, u32, u32, u32, u32, u32);
+    let actual = AStruct(123, 234, 345, 456, 567, 678, 789);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(
+            eq(123),
+            eq(234),
+            eq(345),
+            eq(456),
+            eq(567),
+            eq(678),
+            eq(789)
+        ))
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_eight_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32, u32, u32, u32, u32, u32, u32);
+    let actual = AStruct(123, 234, 345, 456, 567, 678, 789, 890);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(
+            eq(123),
+            eq(234),
+            eq(345),
+            eq(456),
+            eq(567),
+            eq(678),
+            eq(789),
+            eq(890)
+        ))
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_nine_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32, u32, u32, u32, u32, u32, u32, u32);
+    let actual = AStruct(123, 234, 345, 456, 567, 678, 789, 890, 901);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(
+            eq(123),
+            eq(234),
+            eq(345),
+            eq(456),
+            eq(567),
+            eq(678),
+            eq(789),
+            eq(890),
+            eq(901)
+        ))
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_containing_ten_fields() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32, u32, u32, u32, u32, u32, u32, u32, u32);
+    let actual = AStruct(123, 234, 345, 456, 567, 678, 789, 890, 901, 12);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(
+            eq(123),
+            eq(234),
+            eq(345),
+            eq(456),
+            eq(567),
+            eq(678),
+            eq(789),
+            eq(890),
+            eq(901),
+            eq(12)
+        ))
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_with_trailing_comma() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32);
+    let actual = AStruct(123);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(
+            eq(123), // Keep the trailing comma, block reformatting
+        ))
+    )
+}
+
+#[google_test]
+fn matches_tuple_struct_with_two_fields_and_trailing_comma() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(u32, u32);
+    let actual = AStruct(123, 234);
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct(
+            eq(123),
+            eq(234), // Keep the trailing comma, block reformatting
+        ))
+    )
+}
+
+#[google_test]
+fn matches_enum_value() -> Result<()> {
+    #[derive(Debug)]
+    enum AnEnum {
+        A(u32),
+    }
+    let actual = AnEnum::A(123);
+
+    verify_that!(actual, matches_pattern!(AnEnum::A(eq(123))))
+}
+
+#[google_test]
+fn does_not_match_wrong_enum_value() -> Result<()> {
+    #[derive(Debug)]
+    enum AnEnum {
+        #[allow(unused)]
+        A(u32),
+        B,
+    }
+    let actual = AnEnum::B;
+
+    verify_that!(actual, not(matches_pattern!(AnEnum::A(eq(123)))))
+}


### PR DESCRIPTION
The last release included a change which redirected matches_pattern! to matches_pattern_internal!. It did not fix the references inside the macros themselves to use $crate::matches_pattern_internal!. This worked fine in contexts where matches_pattern_internal! was already imported, but does not work in general client code where it is not. This change adds the $crate qualifier to each invocation of matches_pattern_internal!.

This also moves the tests of matches_pattern! out of the module and into a new integration test (see https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html). This causes the tests to be compiled from outside the crate itself, precluding this type of bug in the future.

Fixes #86