### PR TITLE
Replace the type parameter on Matcher with an associated type.

### DIFF
--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -330,9 +330,9 @@ pub mod internal {
     ///
     /// **For internal use only. API stablility is not guaranteed!**
     #[must_use = "The assertion result must be evaluated to affect the test result."]
-    pub fn check_matcher<T: Debug + ?Sized>(
-        actual: &T,
-        expected: impl Matcher<T>,
+    pub fn check_matcher<'a, T: Debug + ?Sized + 'a>(
+        actual: &'a T,
+        expected: impl Matcher<ActualT<'a> = T>,
         actual_expr: &'static str,
         source_location: SourceLocation,
     ) -> Result<(), TestAssertionFailure> {

--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -86,20 +86,20 @@ pub mod internal {
     ///
     /// For internal use only. API stablility is not guaranteed!
     #[doc(hidden)]
-    pub struct AllMatcher<'a, T: Debug + ?Sized, const N: usize> {
-        components: [&'a dyn Matcher<T>; N],
+    pub struct AllMatcher<'a, 'b, T: Debug + ?Sized + 'b, const N: usize> {
+        components: [&'a dyn Matcher<ActualT<'b> = T>; N],
     }
 
-    impl<'a, T: Debug + ?Sized, const N: usize> AllMatcher<'a, T, N> {
+    impl<'a, 'b, T: Debug + ?Sized + 'b, const N: usize> AllMatcher<'a, 'b, T, N> {
         /// Constructs an [`AllMatcher`] with the given component matchers.
         ///
         /// Intended for use only by the [`all`] macro.
-        pub fn new(components: [&'a dyn Matcher<T>; N]) -> Self {
+        pub fn new(components: [&'a dyn Matcher<ActualT<'b> = T>; N]) -> Self {
             Self { components }
         }
     }
 
-    impl<'a, T: Debug + ?Sized, const N: usize> Matcher<T> for AllMatcher<'a, T, N> {
+    impl<'a, 'b, T: Debug + ?Sized + 'b, const N: usize> Matcher for AllMatcher<'a, 'b, T, N> {
         fn matches(&self, actual: &T) -> MatcherResult {
             for component in self.components {
                 match component.matches(actual) {

--- a/googletest/src/matchers/anything_matcher.rs
+++ b/googletest/src/matchers/anything_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches anything. This matcher always succeeds.
 ///
@@ -31,13 +31,15 @@ use std::fmt::Debug;
 /// # }
 /// # should_pass().unwrap();
 /// ```
-pub fn anything<T: Debug + ?Sized>() -> impl Matcher<T> {
-    Anything {}
+pub fn anything<T: Debug + ?Sized>() -> impl Matcher {
+    Anything { phantom: Default::default() }
 }
 
-struct Anything {}
+struct Anything<T: ?Sized> {
+    phantom: PhantomData<T>,
+}
 
-impl<T: Debug + ?Sized> Matcher<T> for Anything {
+impl<T: Debug + ?Sized> Matcher for Anything<T> {
     fn matches(&self, _: &T) -> MatcherResult {
         MatcherResult::Matches
     }

--- a/googletest/src/matchers/container_eq_matcher.rs
+++ b/googletest/src/matchers/container_eq_matcher.rs
@@ -16,7 +16,6 @@ use crate::matcher::{MatchExplanation, Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
 use std::fmt::Debug;
-use std::iter::zip;
 
 /// Matches a container equal (in the sense of `==`) to `expected`.
 ///
@@ -95,8 +94,7 @@ pub struct ContainerEqMatcher<T: Debug> {
     expected: T,
 }
 
-impl<T: PartialEq + Debug, ContainerT: PartialEq + Debug> Matcher<ContainerT>
-    for ContainerEqMatcher<ContainerT>
+impl<T: PartialEq + Debug, ContainerT: PartialEq + Debug> Matcher for ContainerEqMatcher<ContainerT>
 where
     for<'a> &'a ContainerT: IntoIterator<Item = &'a T>,
 {
@@ -106,59 +104,6 @@ where
 
     fn explain_match(&self, actual: &ContainerT) -> MatchExplanation {
         self.explain_match_impl(actual)
-    }
-
-    fn describe(&self, matcher_result: MatcherResult) -> String {
-        self.describe_impl(matcher_result)
-    }
-}
-
-impl<T: PartialEq + Debug, const N: usize> Matcher<Vec<T>> for ContainerEqMatcher<[T; N]> {
-    fn matches(&self, actual: &Vec<T>) -> MatcherResult {
-        (actual.as_slice() == self.expected).into()
-    }
-
-    fn explain_match(&self, actual: &Vec<T>) -> MatchExplanation {
-        self.explain_match_impl(actual)
-    }
-
-    fn describe(&self, matcher_result: MatcherResult) -> String {
-        self.describe_impl(matcher_result)
-    }
-}
-
-impl<T: PartialEq + Debug, const N: usize> Matcher<[T]> for ContainerEqMatcher<[T; N]> {
-    fn matches(&self, actual: &[T]) -> MatcherResult {
-        (actual == self.expected).into()
-    }
-
-    fn explain_match(&self, actual: &[T]) -> MatchExplanation {
-        self.explain_match_impl(actual)
-    }
-
-    fn describe(&self, matcher_result: MatcherResult) -> String {
-        self.describe_impl(matcher_result)
-    }
-}
-
-impl<const N: usize> Matcher<Vec<String>> for ContainerEqMatcher<[&str; N]> {
-    fn matches(&self, actual: &Vec<String>) -> MatcherResult {
-        if actual.len() != self.expected.len() {
-            return MatcherResult::DoesNotMatch;
-        }
-        for (actual_element, expected_element) in zip(actual, self.expected) {
-            if actual_element.as_str() != expected_element {
-                return MatcherResult::DoesNotMatch;
-            }
-        }
-        MatcherResult::Matches
-    }
-
-    fn explain_match(&self, actual: &Vec<String>) -> MatchExplanation {
-        build_explanation(
-            self.get_missing_str_items(actual),
-            self.get_unexpected_string_items(actual),
-        )
     }
 
     fn describe(&self, matcher_result: MatcherResult) -> String {

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -24,20 +24,18 @@ use std::marker::PhantomData;
 /// let result: impl Display = ...;
 /// verify_that!(result, displays_as(eq(format!("{}", result))))?;
 /// ```
-pub fn displays_as<T: Debug + Display, InnerMatcher: Matcher<String>>(
+pub fn displays_as<'a, T: Debug + Display, InnerMatcher: Matcher<ActualT<'a> = String>>(
     inner: InnerMatcher,
-) -> impl Matcher<T> {
+) -> impl Matcher {
     DisplayMatcher { inner, phantom: Default::default() }
 }
 
-struct DisplayMatcher<T, InnerMatcher: Matcher<String>> {
+struct DisplayMatcher<T, InnerMatcher: Matcher> {
     inner: InnerMatcher,
     phantom: PhantomData<T>,
 }
 
-impl<T: Debug + Display, InnerMatcher: Matcher<String>> Matcher<T>
-    for DisplayMatcher<T, InnerMatcher>
-{
+impl<T: Debug + Display, InnerMatcher: Matcher> Matcher for DisplayMatcher<T, InnerMatcher> {
     fn matches(&self, actual: &T) -> MatcherResult {
         self.inner.matches(&format!("{actual}"))
     }

--- a/googletest/src/matchers/each_matcher.rs
+++ b/googletest/src/matchers/each_matcher.rs
@@ -19,7 +19,7 @@ use crate::matchers::description::Description;
 use description::Description;
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a container all of whose elements are matched by the matcher
 /// `inner`.
@@ -61,24 +61,23 @@ use std::fmt::Debug;
 /// # }
 /// # should_pass().unwrap();
 /// ```
-pub fn each<ElementT: Debug, ActualT: Debug + ?Sized, MatcherT>(
-    inner: MatcherT,
-) -> impl Matcher<ActualT>
+pub fn each<'b, ElementT: Debug, ActualT: Debug + ?Sized, MatcherT>(inner: MatcherT) -> impl Matcher
 where
     for<'a> &'a ActualT: IntoIterator<Item = &'a ElementT>,
-    MatcherT: Matcher<ElementT>,
+    MatcherT: Matcher<ActualT<'b> = ElementT>,
 {
-    EachMatcher { inner }
+    EachMatcher { inner, phantom: Default::default() }
 }
 
-struct EachMatcher<MatcherT> {
+struct EachMatcher<ActualT: ?Sized, MatcherT> {
     inner: MatcherT,
+    phantom: PhantomData<ActualT>,
 }
 
-impl<ElementT: Debug, ActualT: Debug + ?Sized, MatcherT> Matcher<ActualT> for EachMatcher<MatcherT>
+impl<ElementT: Debug, ActualT: Debug + ?Sized, MatcherT> Matcher for EachMatcher<ActualT, MatcherT>
 where
     for<'a> &'a ActualT: IntoIterator<Item = &'a ElementT>,
-    MatcherT: Matcher<ElementT>,
+    MatcherT: Matcher,
 {
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         for element in actual {

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -80,7 +80,7 @@ pub mod internal {
     use crate::matchers::zipped_iterator::zip;
     #[cfg(google3)]
     use description::Description;
-    use std::fmt::Debug;
+    use std::{fmt::Debug, marker::PhantomData};
     #[cfg(google3)]
     use zipped_iterator::zip;
 
@@ -88,23 +88,25 @@ pub mod internal {
     ///
     /// **For internal use only. API stablility is not guaranteed!**
     #[doc(hidden)]
-    pub struct ElementsAre<'a, T: Debug> {
-        elements: &'a [&'a dyn Matcher<T>],
+    pub struct ElementsAre<'a, 'b, ContainerT: ?Sized, T: Debug + 'b> {
+        elements: &'a [&'a dyn Matcher<ActualT<'b> = T>],
+        phantom: PhantomData<ContainerT>,
     }
 
-    impl<'a, T: Debug> ElementsAre<'a, T> {
+    impl<'a, 'b, ContainerT: ?Sized, T: Debug + 'b> ElementsAre<'a, 'b, ContainerT, T> {
         /// Factory only intended for use in the macro `elements_are!`.
         ///
         /// **For internal use only. API stablility is not guaranteed!**
         #[doc(hidden)]
-        pub fn new(elements: &'a [&'a dyn Matcher<T>]) -> Self {
-            Self { elements }
+        pub fn new(elements: &'a [&'a dyn Matcher<ActualT<'b> = T>]) -> Self {
+            Self { elements, phantom: Default::default() }
         }
     }
 
-    impl<'a, T: Debug, ContainerT: Debug + ?Sized> Matcher<ContainerT> for ElementsAre<'a, T>
+    impl<'a, 'b, T: Debug + 'b, ContainerT: Debug + ?Sized> Matcher
+        for ElementsAre<'a, 'b, ContainerT, T>
     where
-        for<'b> &'b ContainerT: IntoIterator<Item = &'b T>,
+        for<'c> &'c ContainerT: IntoIterator<Item = &'c T>,
     {
         fn matches(&self, actual: &ContainerT) -> MatcherResult {
             let mut zipped_iterator = zip(actual.into_iter(), self.elements.iter());

--- a/googletest/src/matchers/empty_matcher.rs
+++ b/googletest/src/matchers/empty_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches an empty container.
 ///
@@ -47,16 +47,18 @@ use std::fmt::Debug;
 /// # should_pass().unwrap();
 /// ```
 
-pub fn empty<T: Debug + ?Sized>() -> impl Matcher<T>
+pub fn empty<T: Debug + ?Sized>() -> impl Matcher
 where
     for<'a> &'a T: IntoIterator,
 {
-    EmptyMatcher {}
+    EmptyMatcher { phantom: Default::default() }
 }
 
-struct EmptyMatcher {}
+struct EmptyMatcher<T: ?Sized> {
+    phantom: PhantomData<T>,
+}
 
-impl<T: Debug + ?Sized> Matcher<T> for EmptyMatcher
+impl<T: Debug + ?Sized> Matcher for EmptyMatcher<T>
 where
     for<'a> &'a T: IntoIterator,
 {

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value equal (in the sense of `==`) to `expected`.
 ///
@@ -67,18 +67,19 @@ use std::fmt::Debug;
 ///
 /// You can find the standard library PartialEq implementation in
 /// <https://doc.rust-lang.org/core/cmp/trait.PartialEq.html#implementors>
-pub fn eq<T>(expected: T) -> EqMatcher<T> {
-    EqMatcher { expected }
+pub fn eq<A, T>(expected: T) -> EqMatcher<A, T> {
+    EqMatcher { expected, phantom: Default::default() }
 }
 
 /// A matcher which matches a value equal to `expected`.
 ///
 /// See [`eq`].
-pub struct EqMatcher<T> {
+pub struct EqMatcher<A, T> {
     pub(crate) expected: T,
+    phantom: PhantomData<A>,
 }
 
-impl<A: Debug, T: PartialEq<A> + Debug> Matcher<A> for EqMatcher<T> {
+impl<A: Debug, T: PartialEq<A> + Debug> Matcher for EqMatcher<A, T> {
     fn matches(&self, actual: &A) -> MatcherResult {
         (self.expected == *actual).into()
     }

--- a/googletest/src/matchers/field_matcher.rs
+++ b/googletest/src/matchers/field_matcher.rs
@@ -154,11 +154,11 @@ pub mod internal {
     ///
     /// **For internal use only. API stablility is not guaranteed!**
     #[doc(hidden)]
-    pub fn field_matcher<OuterT: Debug, InnerT: Debug, InnerMatcher: Matcher<InnerT>>(
+    pub fn field_matcher<OuterT: Debug, InnerT: Debug, InnerMatcher: Matcher>(
         field_accessor: fn(&OuterT) -> Option<&InnerT>,
         field_path: &'static str,
         inner: InnerMatcher,
-    ) -> impl Matcher<OuterT> {
+    ) -> impl Matcher {
         FieldMatcher { field_accessor, field_path, inner }
     }
 
@@ -168,7 +168,7 @@ pub mod internal {
         inner: InnerMatcher,
     }
 
-    impl<OuterT: Debug, InnerT: Debug, InnerMatcher: Matcher<InnerT>> Matcher<OuterT>
+    impl<OuterT: Debug, InnerT: Debug, InnerMatcher: Matcher> Matcher
         for FieldMatcher<OuterT, InnerT, InnerMatcher>
     {
         fn matches(&self, actual: &OuterT) -> MatcherResult {

--- a/googletest/src/matchers/ge_matcher.rs
+++ b/googletest/src/matchers/ge_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value greater than or equal to (in the sense of `>=`) `expected`.
 ///
@@ -75,16 +75,17 @@ use std::fmt::Debug;
 /// <https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html#implementors>
 pub fn ge<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug>(
     expected: ExpectedT,
-) -> impl Matcher<ActualT> {
-    GeMatcher { expected }
+) -> impl Matcher {
+    GeMatcher { expected, phantom: Default::default() }
 }
 
-pub struct GeMatcher<ExpectedT> {
+pub struct GeMatcher<ActualT, ExpectedT> {
     expected: ExpectedT,
+    phantom: PhantomData<ActualT>,
 }
 
-impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher<ActualT>
-    for GeMatcher<ExpectedT>
+impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
+    for GeMatcher<ActualT, ExpectedT>
 {
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         (*actual >= self.expected).into()

--- a/googletest/src/matchers/gt_matcher.rs
+++ b/googletest/src/matchers/gt_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value greater (in the sense of `>`) than `expected`.
 ///
@@ -75,16 +75,17 @@ use std::fmt::Debug;
 /// <https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html#implementors>
 pub fn gt<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug>(
     expected: ExpectedT,
-) -> impl Matcher<ActualT> {
-    GtMatcher { expected }
+) -> impl Matcher {
+    GtMatcher { expected, phantom: Default::default() }
 }
 
-struct GtMatcher<ExpectedT> {
+struct GtMatcher<ActualT, ExpectedT> {
     expected: ExpectedT,
+    phantom: PhantomData<ActualT>,
 }
 
-impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher<ActualT>
-    for GtMatcher<ExpectedT>
+impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
+    for GtMatcher<ActualT, ExpectedT>
 {
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         (*actual > self.expected).into()

--- a/googletest/src/matchers/has_entry_matcher.rs
+++ b/googletest/src/matchers/has_entry_matcher.rs
@@ -18,6 +18,7 @@ use googletest::*;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::marker::PhantomData;
 
 /// Matches a HashMap containing the given `key` whose value is matched by the
 /// matcher `inner`.
@@ -62,20 +63,21 @@ use std::hash::Hash;
 /// However, `has_entry` will offer somewhat better diagnostic messages in the
 /// case of assertion failure. And it avoid the extra allocation hidden in the
 /// code above.
-pub fn has_entry<KeyT: Debug + Eq + Hash, ValueT: Debug, MatcherT: Matcher<ValueT>>(
+pub fn has_entry<KeyT: Debug + Eq + Hash, ValueT: Debug, MatcherT: Matcher>(
     key: KeyT,
     inner: MatcherT,
-) -> impl Matcher<HashMap<KeyT, ValueT>> {
-    HasEntryMatcher { key, inner }
+) -> impl Matcher {
+    HasEntryMatcher { key, inner, phantom: Default::default() }
 }
 
-struct HasEntryMatcher<KeyT, MatcherT> {
+struct HasEntryMatcher<KeyT, ValueT, MatcherT> {
     key: KeyT,
     inner: MatcherT,
+    phantom: PhantomData<ValueT>,
 }
 
-impl<KeyT: Debug + Eq + Hash, ValueT: Debug, MatcherT: Matcher<ValueT>>
-    Matcher<HashMap<KeyT, ValueT>> for HasEntryMatcher<KeyT, MatcherT>
+impl<KeyT: Debug + Eq + Hash, ValueT: Debug, MatcherT: Matcher> Matcher
+    for HasEntryMatcher<KeyT, ValueT, MatcherT>
 {
     fn matches(&self, actual: &HashMap<KeyT, ValueT>) -> MatcherResult {
         if let Some(value) = actual.get(&self.key) {

--- a/googletest/src/matchers/is_nan_matcher.rs
+++ b/googletest/src/matchers/is_nan_matcher.rs
@@ -16,16 +16,16 @@ use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
 use num_traits::float::Float;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a floating point value which is NaN.
-pub fn is_nan<T: Float + Debug>() -> impl Matcher<T> {
-    IsNanMatcher
+pub fn is_nan<T: Float + Debug>() -> impl Matcher {
+    IsNanMatcher(Default::default())
 }
 
-struct IsNanMatcher;
+struct IsNanMatcher<T>(PhantomData<T>);
 
-impl<T: Float + Debug> Matcher<T> for IsNanMatcher {
+impl<T: Float + Debug> Matcher for IsNanMatcher<T> {
     fn matches(&self, actual: &T) -> MatcherResult {
         actual.is_nan().into()
     }

--- a/googletest/src/matchers/le_matcher.rs
+++ b/googletest/src/matchers/le_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value less than or equal to (in the sense of `<=`) `expected`.
 ///
@@ -75,16 +75,17 @@ use std::fmt::Debug;
 /// <https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html#implementors>
 pub fn le<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug>(
     expected: ExpectedT,
-) -> impl Matcher<ActualT> {
-    LeMatcher { expected }
+) -> impl Matcher {
+    LeMatcher { expected, phantom: Default::default() }
 }
 
-pub struct LeMatcher<ExpectedT> {
+pub struct LeMatcher<ActualT, ExpectedT> {
     expected: ExpectedT,
+    phantom: PhantomData<ActualT>,
 }
 
-impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher<ActualT>
-    for LeMatcher<ExpectedT>
+impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
+    for LeMatcher<ActualT, ExpectedT>
 {
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         (*actual <= self.expected).into()

--- a/googletest/src/matchers/lt_matcher.rs
+++ b/googletest/src/matchers/lt_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value less (in the sense of `<`) than `expected`.
 ///
@@ -75,17 +75,16 @@ use std::fmt::Debug;
 /// <https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html#implementors>
 pub fn lt<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug>(
     expected: ExpectedT,
-) -> impl Matcher<ActualT> {
-    LtMatcher { expected }
+) -> impl Matcher {
+    LtMatcher { expected, phantom: Default::default() }
 }
 
-pub struct LtMatcher<ExpectedT> {
+pub struct LtMatcher<ActualT, ExpectedT> {
     expected: ExpectedT,
+    phantom: PhantomData<ActualT>,
 }
 
-impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher<ActualT>
-    for LtMatcher<ExpectedT>
-{
+impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher for LtMatcher<ActualT, ExpectedT> {
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         (*actual < self.expected).into()
     }

--- a/googletest/src/matchers/near_matcher.rs
+++ b/googletest/src/matchers/near_matcher.rs
@@ -165,7 +165,7 @@ impl<T: Debug> NearMatcher<T> {
     }
 }
 
-impl<T: Debug + Float> Matcher<T> for NearMatcher<T> {
+impl<T: Debug + Float> Matcher for NearMatcher<T> {
     fn matches(&self, actual: &T) -> MatcherResult {
         if self.nans_are_equal && self.expected.is_nan() && actual.is_nan() {
             return MatcherResult::Matches;

--- a/googletest/src/matchers/none_matcher.rs
+++ b/googletest/src/matchers/none_matcher.rs
@@ -33,7 +33,7 @@ use std::marker::PhantomData;
 /// # should_pass().unwrap();
 /// # should_fail().unwrap_err();
 /// ```
-pub fn none<T: Debug>() -> impl Matcher<Option<T>> {
+pub fn none<T: Debug>() -> impl Matcher {
     NoneMatcher { phantom: Default::default() }
 }
 
@@ -41,7 +41,7 @@ struct NoneMatcher<T> {
     phantom: PhantomData<T>,
 }
 
-impl<T: Debug> Matcher<Option<T>> for NoneMatcher<T> {
+impl<T: Debug> Matcher for NoneMatcher<T> {
     fn matches(&self, actual: &Option<T>) -> MatcherResult {
         (actual.is_none()).into()
     }

--- a/googletest/src/matchers/not_matcher.rs
+++ b/googletest/src/matchers/not_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{MatchExplanation, Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches the actual value exactly when the inner matcher does _not_ match.
 ///
@@ -32,15 +32,16 @@ use std::fmt::Debug;
 /// # should_pass().unwrap();
 /// # should_fail().unwrap_err();
 /// ```
-pub fn not<T: Debug, InnerMatcherT: Matcher<T>>(inner: InnerMatcherT) -> impl Matcher<T> {
-    NotMatcher { inner }
+pub fn not<T: Debug, InnerMatcherT: Matcher>(inner: InnerMatcherT) -> impl Matcher {
+    NotMatcher { inner, phantom: Default::default() }
 }
 
-struct NotMatcher<InnerMatcherT> {
+struct NotMatcher<T, InnerMatcherT> {
     inner: InnerMatcherT,
+    phantom: PhantomData<T>,
 }
 
-impl<T: Debug, InnerMatcherT: Matcher<T>> Matcher<T> for NotMatcher<InnerMatcherT> {
+impl<T: Debug, InnerMatcherT: Matcher> Matcher for NotMatcher<T, InnerMatcherT> {
     fn matches(&self, actual: &T) -> MatcherResult {
         match self.inner.matches(actual) {
             MatcherResult::Matches => MatcherResult::DoesNotMatch,

--- a/googletest/src/matchers/points_to_matcher.rs
+++ b/googletest/src/matchers/points_to_matcher.rs
@@ -16,6 +16,7 @@ use crate::matcher::{MatchExplanation, Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::ops::Deref;
 
 /// Matches a (smart) pointer pointing to a value matched by the [`Matcher`]
@@ -32,23 +33,24 @@ use std::ops::Deref;
 /// # }
 /// # should_pass().unwrap();
 /// ```
-pub fn points_to<ExpectedT, MatcherT, ActualT>(expected: MatcherT) -> impl Matcher<ActualT>
+pub fn points_to<ExpectedT, MatcherT, ActualT>(expected: MatcherT) -> impl Matcher
 where
     ExpectedT: Debug,
-    MatcherT: Matcher<ExpectedT>,
+    MatcherT: Matcher,
     ActualT: Deref<Target = ExpectedT> + Debug + ?Sized,
 {
-    PointsToMatcher { expected }
+    PointsToMatcher { expected, phantom: Default::default() }
 }
 
-struct PointsToMatcher<MatcherT> {
+struct PointsToMatcher<ActualT: ?Sized, MatcherT> {
     expected: MatcherT,
+    phantom: PhantomData<ActualT>,
 }
 
-impl<ExpectedT, MatcherT, ActualT> Matcher<ActualT> for PointsToMatcher<MatcherT>
+impl<ExpectedT, MatcherT, ActualT> Matcher for PointsToMatcher<ActualT, MatcherT>
 where
     ExpectedT: Debug,
-    MatcherT: Matcher<ExpectedT>,
+    MatcherT: Matcher,
     ActualT: Deref<Target = ExpectedT> + Debug + ?Sized,
 {
     fn matches(&self, actual: &ActualT) -> MatcherResult {

--- a/googletest/src/matchers/pointwise_matcher.rs
+++ b/googletest/src/matchers/pointwise_matcher.rs
@@ -156,7 +156,7 @@ pub mod internal {
     use crate::matchers::zipped_iterator::zip;
     #[cfg(google3)]
     use description::Description;
-    use std::fmt::Debug;
+    use std::{fmt::Debug, marker::PhantomData};
     #[cfg(google3)]
     use zipped_iterator::zip;
 
@@ -164,18 +164,19 @@ pub mod internal {
     ///
     /// **For internal use only. API stablility is not guaranteed!**
     #[doc(hidden)]
-    pub struct PointwiseMatcher<MatcherT> {
+    pub struct PointwiseMatcher<ContainerT: ?Sized, MatcherT> {
         matchers: Vec<MatcherT>,
+        phantom: PhantomData<ContainerT>,
     }
 
-    impl<MatcherT> PointwiseMatcher<MatcherT> {
+    impl<ContainerT: ?Sized, MatcherT> PointwiseMatcher<ContainerT, MatcherT> {
         pub fn new(matchers: Vec<MatcherT>) -> Self {
-            Self { matchers }
+            Self { matchers, phantom: Default::default() }
         }
     }
 
-    impl<T: Debug, MatcherT: Matcher<T>, ContainerT: ?Sized + Debug> Matcher<ContainerT>
-        for PointwiseMatcher<MatcherT>
+    impl<T: Debug, MatcherT: Matcher, ContainerT: ?Sized + Debug> Matcher
+        for PointwiseMatcher<ContainerT, MatcherT>
     where
         for<'b> &'b ContainerT: IntoIterator<Item = &'b T>,
     {

--- a/googletest/src/matchers/predicate_matcher.rs
+++ b/googletest/src/matchers/predicate_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Creates a matcher based on the predicate provided.
 ///
@@ -37,7 +37,7 @@ use std::fmt::Debug;
 /// This is easily fixed by explicitly declaring the type of the argument
 pub fn predicate<T: Debug + ?Sized, P>(
     predicate: P,
-) -> PredicateMatcher<P, NoDescription, NoDescription>
+) -> PredicateMatcher<T, P, NoDescription, NoDescription>
 where
     for<'a> P: Fn(&'a T) -> bool,
 {
@@ -45,10 +45,11 @@ where
         predicate,
         positive_description: NoDescription,
         negative_description: NoDescription,
+        phantom: Default::default(),
     }
 }
 
-impl<P> PredicateMatcher<P, NoDescription, NoDescription> {
+impl<T, P> PredicateMatcher<T, P, NoDescription, NoDescription> {
     /// Configures this instance to provide a more meaningful description.
     ///
     /// For example, to make sure the error message is more useful
@@ -65,18 +66,24 @@ impl<P> PredicateMatcher<P, NoDescription, NoDescription> {
         self,
         positive_description: D1,
         negative_description: D2,
-    ) -> PredicateMatcher<P, D1, D2> {
-        PredicateMatcher { predicate: self.predicate, positive_description, negative_description }
+    ) -> PredicateMatcher<T, P, D1, D2> {
+        PredicateMatcher {
+            predicate: self.predicate,
+            positive_description,
+            negative_description,
+            phantom: Default::default(),
+        }
     }
 }
 
 /// A matcher which applies `predicate` on the value.
 ///
 /// See [`predicate`].
-pub struct PredicateMatcher<P, D1, D2> {
+pub struct PredicateMatcher<T: ?Sized, P, D1, D2> {
     predicate: P,
     positive_description: D1,
     negative_description: D2,
+    phantom: PhantomData<T>,
 }
 
 /// A trait to allow [`PredicateMatcher::with_description`] to accept multiple
@@ -113,7 +120,7 @@ where
 #[doc(hidden)]
 pub struct NoDescription;
 
-impl<T: Debug, P> Matcher<T> for PredicateMatcher<P, NoDescription, NoDescription>
+impl<T: Debug, P> Matcher for PredicateMatcher<T, P, NoDescription, NoDescription>
 where
     for<'a> P: Fn(&'a T) -> bool,
 {
@@ -129,8 +136,8 @@ where
     }
 }
 
-impl<T: Debug, P, D1: PredicateDescription, D2: PredicateDescription> Matcher<T>
-    for PredicateMatcher<P, D1, D2>
+impl<T: Debug, P, D1: PredicateDescription, D2: PredicateDescription> Matcher
+    for PredicateMatcher<T, P, D1, D2>
 where
     for<'a> P: Fn(&'a T) -> bool,
 {
@@ -155,7 +162,7 @@ mod tests {
     use matchers::{displays_as, eq};
 
     // Simple matcher with a description
-    fn is_odd() -> impl Matcher<i32> {
+    fn is_odd() -> impl Matcher {
         predicate(|x| x % 2 == 1).with_description("is odd", "is even")
     }
 
@@ -175,7 +182,7 @@ mod tests {
     }
 
     // Simple Matcher without description
-    fn is_even() -> impl Matcher<i32> {
+    fn is_even() -> impl Matcher {
         predicate(|x| x % 2 == 0)
     }
 

--- a/googletest/src/matchers/some_matcher.rs
+++ b/googletest/src/matchers/some_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{MatchExplanation, Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches an `Option` containing a value matched by `inner`.
 ///
@@ -37,15 +37,16 @@ use std::fmt::Debug;
 /// # should_fail_1().unwrap_err();
 /// # should_fail_2().unwrap_err();
 /// ```
-pub fn some<T: Debug>(inner: impl Matcher<T>) -> impl Matcher<Option<T>> {
-    SomeMatcher { inner }
+pub fn some<T: Debug>(inner: impl Matcher) -> impl Matcher {
+    SomeMatcher { inner, phantom: Default::default() }
 }
 
-struct SomeMatcher<InnerMatcherT> {
+struct SomeMatcher<T, InnerMatcherT> {
     inner: InnerMatcherT,
+    phantom: PhantomData<T>,
 }
 
-impl<T: Debug, InnerMatcherT: Matcher<T>> Matcher<Option<T>> for SomeMatcher<InnerMatcherT> {
+impl<T: Debug, InnerMatcherT: Matcher> Matcher for SomeMatcher<T, InnerMatcherT> {
     fn matches(&self, actual: &Option<T>) -> MatcherResult {
         actual.as_ref().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::DoesNotMatch)
     }

--- a/googletest/src/matchers/subset_of_matcher.rs
+++ b/googletest/src/matchers/subset_of_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{MatchExplanation, Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a container all of whose items are in the given container
 /// `superset`.
@@ -81,20 +81,21 @@ use std::fmt::Debug;
 /// items. It should not be used on especially large containers.
 pub fn subset_of<ElementT: Debug + PartialEq, ActualT: Debug + ?Sized, ExpectedT: Debug>(
     superset: ExpectedT,
-) -> impl Matcher<ActualT>
+) -> impl Matcher
 where
     for<'a> &'a ActualT: IntoIterator<Item = &'a ElementT>,
     for<'a> &'a ExpectedT: IntoIterator<Item = &'a ElementT>,
 {
-    SubsetOfMatcher { superset }
+    SubsetOfMatcher { superset, phantom: Default::default() }
 }
 
-struct SubsetOfMatcher<ExpectedT> {
+struct SubsetOfMatcher<ActualT: ?Sized, ExpectedT> {
     superset: ExpectedT,
+    phantom: PhantomData<ActualT>,
 }
 
-impl<ElementT: Debug + PartialEq, ActualT: Debug + ?Sized, ExpectedT: Debug> Matcher<ActualT>
-    for SubsetOfMatcher<ExpectedT>
+impl<ElementT: Debug + PartialEq, ActualT: Debug + ?Sized, ExpectedT: Debug> Matcher
+    for SubsetOfMatcher<ActualT, ExpectedT>
 where
     for<'a> &'a ActualT: IntoIterator<Item = &'a ElementT>,
     for<'a> &'a ExpectedT: IntoIterator<Item = &'a ElementT>,
@@ -137,7 +138,7 @@ where
     }
 }
 
-impl<ElementT: PartialEq, ExpectedT> SubsetOfMatcher<ExpectedT>
+impl<ActualT, ElementT: PartialEq, ExpectedT> SubsetOfMatcher<ActualT, ExpectedT>
 where
     for<'a> &'a ExpectedT: IntoIterator<Item = &'a ElementT>,
 {

--- a/googletest/src/matchers/superset_of_matcher.rs
+++ b/googletest/src/matchers/superset_of_matcher.rs
@@ -15,7 +15,7 @@
 use crate::matcher::{MatchExplanation, Matcher, MatcherResult};
 #[cfg(google3)]
 use googletest::*;
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a container containing all of the items in the given container
 /// `subset`.
@@ -81,20 +81,21 @@ use std::fmt::Debug;
 /// items. It should not be used on especially large containers.
 pub fn superset_of<ElementT: Debug + PartialEq, ActualT: Debug + ?Sized, ExpectedT: Debug>(
     subset: ExpectedT,
-) -> impl Matcher<ActualT>
+) -> impl Matcher
 where
     for<'a> &'a ActualT: IntoIterator<Item = &'a ElementT>,
     for<'a> &'a ExpectedT: IntoIterator<Item = &'a ElementT>,
 {
-    SupersetOfMatcher { subset }
+    SupersetOfMatcher { subset, phantom: Default::default() }
 }
 
-struct SupersetOfMatcher<ExpectedT> {
+struct SupersetOfMatcher<ActualT: ?Sized, ExpectedT> {
     subset: ExpectedT,
+    phantom: PhantomData<ActualT>,
 }
 
-impl<ElementT: Debug + PartialEq, ActualT: Debug + ?Sized, ExpectedT: Debug> Matcher<ActualT>
-    for SupersetOfMatcher<ExpectedT>
+impl<ElementT: Debug + PartialEq, ActualT: Debug + ?Sized, ExpectedT: Debug> Matcher
+    for SupersetOfMatcher<ActualT, ExpectedT>
 where
     for<'a> &'a ActualT: IntoIterator<Item = &'a ElementT>,
     for<'a> &'a ExpectedT: IntoIterator<Item = &'a ElementT>,

--- a/googletest/src/matchers/tuple_matcher.rs
+++ b/googletest/src/matchers/tuple_matcher.rs
@@ -293,7 +293,10 @@ macro_rules! tuple_internal {
 #[doc(hidden)]
 pub mod internal {
     use crate::matcher::{MatchExplanation, Matcher, MatcherResult};
-    use std::fmt::{Debug, Write};
+    use std::{
+        fmt::{Debug, Write},
+        marker::PhantomData,
+    };
 
     /// Replaces the first expression with the second at compile time.
     ///
@@ -316,10 +319,10 @@ pub mod internal {
     macro_rules! tuple_matcher_n {
         ($name:ident, $([$field_number:tt, $matcher_type:ident, $field_type:ident]),*) => {
             #[doc(hidden)]
-            pub struct $name<$($matcher_type),*>($(pub $matcher_type),*);
+            pub struct $name<$($field_type, $matcher_type),*>($(pub $matcher_type),*, $(PhantomData<$field_type>),*);
 
-            impl<$($field_type: Debug, $matcher_type: Matcher<$field_type>),*>
-                Matcher<($($field_type,)*)> for $name<$($matcher_type),*>
+            impl<$($field_type: Debug, $matcher_type: Matcher),*>
+                Matcher for $name<$($field_type, $matcher_type),*>
             {
                 fn matches(&self, actual: &($($field_type,)*)) -> MatcherResult {
                     $(match self.$field_number.matches(&actual.$field_number) {


### PR DESCRIPTION
This should make it possible to associate a lifetime with the actual value in such a way as to allow the property matcher to work with extractors which return data referencing the containing struct.

This unfortunately does not completely work at the moment since some matchers use trait objects and generic associated types are not yet object-safe (see https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#traits-with-gats-are-not-object-safe). This may change in the future.