### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,26 @@ members = [
   "googletest_macro",
   "googletest",
 ]
+
+[package]
+name = "googletest-rust"
+version = "0.1.0"
+edition = "2018"
+description = "A Rust binding to Google Test"
+repository = "https://github.com/google/googletest-rust"
+license = "Apache-2.0"
+
+[badges]
+travis-ci = { repository = "google/googletest-rust" }
+codecov = { repository = "google/googletest-rust" }
+
+[dependencies]
+googletest = { version = "0.9.0", default-features = false }
+
+[[bin]]
+name = "example1"
+path = "examples/example1.rs"
+
+[[bin]]
+name = "example2"
+path = "examples/example2.rs"


### PR DESCRIPTION
To ensure that the package is using the latest Rust features and syntax, you can specify the Rust 2018 edition by using edition = "2018". This is the default edition for Rust 1.31 and newer.

When specifying binary targets in the package, it's recommended to use [[bin]] instead of [[example]]. The [[example]] section should be used for examples that are not built by default, while [[bin]] is used for binaries that are built by default and can be run using cargo run.

it should need more changes
