### PR TITLE
Make `AllMatcher` own its inner matchers.

### DIFF
--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -54,7 +54,7 @@
 macro_rules! all {
     ($($matcher:expr),* $(,)?) => {{
         use $crate::matchers::all_matcher::internal::AllMatcher;
-        AllMatcher::new([$(&$matcher),*])
+        AllMatcher::new([$(Box::new($matcher)),*])
     }}
 }
 
@@ -73,24 +73,24 @@ pub mod internal {
     ///
     /// For internal use only. API stablility is not guaranteed!
     #[doc(hidden)]
-    pub struct AllMatcher<'a, T: Debug + ?Sized, const N: usize> {
-        components: [&'a dyn Matcher<ActualT = T>; N],
+    pub struct AllMatcher<T: Debug + ?Sized, const N: usize> {
+        components: [Box<dyn Matcher<ActualT = T>>; N],
     }
 
-    impl<'a, T: Debug + ?Sized, const N: usize> AllMatcher<'a, T, N> {
+    impl<T: Debug + ?Sized, const N: usize> AllMatcher<T, N> {
         /// Constructs an [`AllMatcher`] with the given component matchers.
         ///
         /// Intended for use only by the [`all`] macro.
-        pub fn new(components: [&'a dyn Matcher<ActualT = T>; N]) -> Self {
+        pub fn new(components: [Box<dyn Matcher<ActualT = T>>; N]) -> Self {
             Self { components }
         }
     }
 
-    impl<'a, T: Debug + ?Sized, const N: usize> Matcher for AllMatcher<'a, T, N> {
+    impl<T: Debug + ?Sized, const N: usize> Matcher for AllMatcher<T, N> {
         type ActualT = T;
 
         fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
-            for component in self.components {
+            for component in &self.components {
                 match component.matches(actual) {
                     MatcherResult::DoesNotMatch => {
                         return MatcherResult::DoesNotMatch;

--- a/googletest/tests/composition_test.rs
+++ b/googletest/tests/composition_test.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use googletest::prelude::*;
+
+#[test]
+fn all_matcher_works_as_inner_matcher() -> Result<()> {
+    let value = vec![1];
+    verify_that!(value, contains_each![all!(gt(0), lt(2))])
+}
+
+#[test]
+fn matches_pattern_works_as_inner_matcher() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(i32);
+    verify_that!(vec![AStruct(123)], contains_each![matches_pattern!(AStruct(eq(123)))])
+}
+
+#[test]
+fn matches_pattern_works_with_property_as_inner_matcher() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(i32);
+    impl AStruct {
+        fn get_value(&self) -> i32 {
+            self.0
+        }
+    }
+    verify_that!(
+        vec![AStruct(123)],
+        contains_each![matches_pattern!(AStruct {
+            get_value(): eq(123)
+        })]
+    )
+}
+
+#[test]
+fn contains_each_works_as_inner_matcher() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(Vec<i32>);
+    verify_that!(AStruct(vec![123]), matches_pattern!(AStruct(contains_each![eq(123)])))
+}
+
+#[test]
+fn pointwise_works_as_inner_matcher() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(Vec<i32>);
+    verify_that!(AStruct(vec![123]), matches_pattern!(AStruct(pointwise!(eq, [123]))))
+}
+
+#[test]
+fn elements_are_works_as_inner_matcher() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct(Vec<i32>);
+    verify_that!(AStruct(vec![123]), matches_pattern!(AStruct(elements_are![eq(123)])))
+}
+
+#[test]
+fn tuple_works_as_inner_matcher() -> Result<()> {
+    verify_that!(vec![(123,)], elements_are![tuple!(eq(123))])
+}

--- a/googletest/tests/lib.rs
+++ b/googletest/tests/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod all_matcher_test;
+mod composition_test;
 mod elements_are_matcher_test;
 mod field_matcher_test;
 mod matches_pattern_test;


### PR DESCRIPTION
Previously, `AllMatcher` along with other matchers such as `ElementsAreMatcher` and `UnorderedElementsAreMatcher` would only contain references to their inner matchers. A prior change updated the latter matchers so that they would put these inner matchers in `Box`, making them owned. This change missed `AllMatcher`, the consequence of which is that `AllMatcher` could not be an inner matcher of any of the aforementioned matchers without breaking Rust's borrow checking rules. This also broke any use of `matches_pattern!` as an inner matcher in one of the modified matchers.

This change updates `AllMatcher` to use the same semantics as the other matchers which previously took references to inner matchers, also fixing `matches_pattern!`. It also adds a module of "composition tests" which exercise various matchers in different compositional arrangements to help avoid such problems in the future.