### PR TITLE
Allow omitting elements_are! and unordered_elements_are!

### DIFF
--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -54,6 +54,22 @@
 /// ```
 #[macro_export]
 macro_rules! verify_that {
+    ($actual:expr, [$($expecteds:expr),+]) => {
+        $crate::assertions::internal::check_matcher(
+            &$actual,
+            $crate::elements_are![$($expecteds),+],
+            stringify!($actual),
+            $crate::internal::source_location::SourceLocation::new(file!(), line!(), column!()),
+        )
+    };
+    ($actual:expr, {$($expecteds:expr),+}) => {
+        $crate::assertions::internal::check_matcher(
+            &$actual,
+            $crate::unordered_elements_are![$($expecteds),+],
+            stringify!($actual),
+            $crate::internal::source_location::SourceLocation::new(file!(), line!(), column!()),
+        )
+    };
     ($actual:expr, $expected:expr) => {
         $crate::assertions::internal::check_matcher(
             &$actual,

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -39,6 +39,14 @@
 /// #    .unwrap();
 /// ```
 ///
+/// This can also be omitted in [`verify_that!`] macros and replaced with square brackets.
+/// 
+/// ```
+/// # use googletest::prelude::*;
+///  verify_that!(vec![1, 2], [eq(1), eq(2)])
+/// #     .unwrap();
+/// ```
+/// 
 /// This matcher does not support matching directly against an [`Iterator`]. To
 /// match against an iterator, use [`Iterator::collect`] to build a [`Vec`].
 ///

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -40,13 +40,28 @@
 /// ```
 ///
 /// This can also be omitted in [`verify_that!`] macros and replaced with square brackets.
-/// 
+///
 /// ```
 /// # use googletest::prelude::*;
 ///  verify_that!(vec![1, 2], [eq(1), eq(2)])
 /// #     .unwrap();
 /// ```
-/// 
+///
+/// Note: This behavior is only possible in [`verify_that!`] macros. In any other cases, it is still necessary to use the [`elements_are!`] macro.
+///
+/// ```compile_fail
+/// # use googletest::prelude::*;
+/// verify_that!(vec![vec![1,2], vec![3]], [[eq(1), eq(2)], [eq(3)]])
+/// # .unwrap();
+/// ```
+///
+/// Prefer:
+/// ```
+/// # use googletest::prelude::*;
+/// verify_that!(vec![vec![1,2], vec![3]], [elements_are![eq(1), eq(2)], elements_are![eq(3)]])
+/// # .unwrap();
+/// ```
+///
 /// This matcher does not support matching directly against an [`Iterator`]. To
 /// match against an iterator, use [`Iterator::collect`] to build a [`Vec`].
 ///

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -62,13 +62,30 @@
 /// ```
 ///
 /// This can also be omitted in [`verify_that!`] macros and replaced with curly brackets.
-/// 
+///
 /// ```
 /// # use googletest::prelude::*;
 ///  verify_that!(vec![1, 2], {eq(2), eq(1)})
 /// #     .unwrap();
 /// ```
-/// 
+///
+/// Note: This behavior is only possible in [`verify_that!`] macros. In any other cases, it is still necessary
+/// to use the [`unordered_elements_are!`] macro.
+///
+/// ```compile_fail
+/// # use googletest::prelude::*;
+/// verify_that!(vec![vec![1,2], vec![3]], {{eq(2), eq(1)}, {eq(3)}})
+/// # .unwrap();
+/// ```
+///
+/// Prefer:
+/// ```
+/// # use googletest::prelude::*;
+/// verify_that!(vec![vec![1,2], vec![3]],
+///   {unordered_elements_are![eq(2), eq(1)], unordered_elements_are![eq(3)]})
+/// # .unwrap();
+/// ```
+///
 /// This matcher does not support matching directly against an [`Iterator`]. To
 /// match against an iterator, use [`Iterator::collect`] to build a [`Vec`].
 ///

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -61,6 +61,14 @@
 /// #     .unwrap();
 /// ```
 ///
+/// This can also be omitted in [`verify_that!`] macros and replaced with curly brackets.
+/// 
+/// ```
+/// # use googletest::prelude::*;
+///  verify_that!(vec![1, 2], {eq(2), eq(1)})
+/// #     .unwrap();
+/// ```
+/// 
 /// This matcher does not support matching directly against an [`Iterator`]. To
 /// match against an iterator, use [`Iterator::collect`] to build a [`Vec`].
 ///

--- a/googletest/tests/elements_are_matcher_test.rs
+++ b/googletest/tests/elements_are_matcher_test.rs
@@ -119,8 +119,7 @@ fn elements_are_works_when_matcher_is_created_in_subroutine() -> Result<()> {
     verify_that!(vec![1], create_matcher())
 }
 
-
 #[test]
 fn elements_are_implicitly_called() -> Result<()> {
-    verify_that!(vec![1,2,3], [eq(1), eq(2), eq(3)])
+    verify_that!(vec![1, 2, 3], [eq(1), eq(2), eq(3)])
 }

--- a/googletest/tests/elements_are_matcher_test.rs
+++ b/googletest/tests/elements_are_matcher_test.rs
@@ -118,3 +118,9 @@ fn create_matcher() -> impl Matcher<ActualT = Vec<i32>> {
 fn elements_are_works_when_matcher_is_created_in_subroutine() -> Result<()> {
     verify_that!(vec![1], create_matcher())
 }
+
+
+#[test]
+fn elements_are_implicitly_called() -> Result<()> {
+    verify_that!(vec![1,2,3], [eq(1), eq(2), eq(3)])
+}

--- a/googletest/tests/unordered_elements_are_matcher_test.rs
+++ b/googletest/tests/unordered_elements_are_matcher_test.rs
@@ -36,6 +36,12 @@ fn unordered_elements_are_matches_vector() -> Result<()> {
 }
 
 #[test]
+fn unordered_elements_are_omitted() -> Result<()> {
+    let value = vec![1, 2, 3];
+    verify_that!(value, {eq(1), eq(2), eq(3)})
+}
+
+#[test]
 fn unordered_elements_are_matches_slice() -> Result<()> {
     let value = vec![1, 2, 3];
     let slice = value.as_slice();

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -148,3 +148,8 @@ test = false
 name = "verify_predicate_with_failure_as_method_in_submodule"
 path = "src/verify_predicate_with_failure_as_method_in_submodule.rs"
 test = false
+
+[[bin]]
+name = "verify_that_omitted_container_matcher"
+path = "src/verify_that_omitted_container_matcher.rs"
+test = false

--- a/integration_tests/src/verify_that_omitted_container_matcher.rs
+++ b/integration_tests/src/verify_that_omitted_container_matcher.rs
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use googletest::prelude::*;
+
+    #[googletest::test]
+    fn verify_that_ordered_elements_omitted() -> Result<()> {
+        verify_that!(vec![1, 2], [eq(1), eq(2)])
+    }
+
+    #[googletest::test]
+    fn verify_that_unordered_elements_omitted() -> Result<()> {
+        verify_that!(vec![1, 2], {eq(2), eq(1)})
+    }
+}

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -46,6 +46,7 @@ INTEGRATION_TEST_BINARIES=(
   "two_non_fatal_failures"
   "verify_predicate_with_failure"
   "verify_predicate_with_failure_as_method_in_submodule"
+  "verify_that_omitted_container_matcher"
 )
 
 cargo build


### PR DESCRIPTION
This changes provide the syntactic sugar that transform:
```
verify_that!(actual, [...])
verify_that!(actual, {...})
```
into
```
verify_that!(actual, elements_are![...])
verify_that!(actual, unordered_elements_are![...])
```

This syntactic sugar currently only works in the `verify_that!` macros. Hence, 
```
verify_that!(vec![vec![1,2], vec![2]], [[eq(1), eq(2)], [eq(2)]])
```

This could be changed in the future by extending this syntactic sugar to other macros. However, this will not be possible for function matchers. Hence, with the current approach
```
verify_that!(vec![vec![1], vec![1]], each([eq(1)]))
```
would never work.