### PR TITLE
Add a shim to ease integration with the [proptest](https://crates.io/crates/proptest) crate.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     name: test / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable, 1.59.0, nightly, beta]
+        toolchain: [stable, nightly, beta]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.toolchain }}
@@ -62,7 +62,7 @@ jobs:
     name: test (no default features) / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable]
+        toolchain: [stable, 1.59]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.toolchain }}

--- a/googletest/Cargo.toml
+++ b/googletest/Cargo.toml
@@ -32,10 +32,11 @@ authors = [
 
 [dependencies]
 googletest_macro = { path = "../googletest_macro", version = "0.8.1" }
+ansi_term = "0.12.0"
 anyhow = { version = "1", optional = true }
 num-traits = "0.2.15"
 regex = "1.6.0"
-ansi_term = "0.12.0"
+proptest = { version = "1.2.0", optional = true }
 
 [dev-dependencies]
 indoc = "2"

--- a/googletest/src/internal/test_outcome.rs
+++ b/googletest/src/internal/test_outcome.rs
@@ -163,3 +163,10 @@ impl<T: std::error::Error> From<T> for TestAssertionFailure {
         TestAssertionFailure::create(format!("{value}"))
     }
 }
+
+#[cfg(feature = "proptest")]
+impl From<TestAssertionFailure> for proptest::test_runner::TestCaseError {
+    fn from(value: TestAssertionFailure) -> Self {
+        proptest::test_runner::TestCaseError::Fail(format!("{value}").into())
+    }
+}

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -232,3 +232,12 @@ impl<T> IntoTestResult<T> for std::result::Result<T, anyhow::Error> {
         self.map_err(|e| TestAssertionFailure::create(format!("{e}")))
     }
 }
+
+#[cfg(feature = "proptest")]
+impl<OkT, CaseT: std::fmt::Debug> IntoTestResult<OkT>
+    for std::result::Result<OkT, proptest::test_runner::TestError<CaseT>>
+{
+    fn into_test_result(self) -> std::result::Result<OkT, TestAssertionFailure> {
+        self.map_err(|e| TestAssertionFailure::create(format!("{e}")))
+    }
+}

--- a/googletest/tests/proptest_integration_test.rs
+++ b/googletest/tests/proptest_integration_test.rs
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod all_matcher_test;
-mod composition_test;
-mod elements_are_matcher_test;
-mod field_matcher_test;
-mod matches_pattern_test;
-mod pointwise_matcher_test;
-mod property_matcher_test;
-#[cfg(feature = "proptest")]
-mod proptest_integration_test;
-mod tuple_matcher_test;
-mod unordered_elements_are_matcher_test;
+#![cfg(feature = "proptest")]
+
+use googletest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
+
+#[test]
+fn numbers_are_greater_than_zero() -> Result<()> {
+    let mut runner = TestRunner::new(Config::default());
+    runner.run(&(1..100i32), |v| Ok(verify_that!(v, gt(0))?)).into_test_result()
+}
+
+#[test]
+fn strings_are_nonempty() -> Result<()> {
+    let mut runner = TestRunner::new(Config::default());
+    runner.run(&"[a-zA-Z0-9]+", |v| Ok(verify_that!(v, not(eq("")))?)).into_test_result()
+}


### PR DESCRIPTION
Previously, it was awkward to use GoogleTest Rust assertions in Proptest property tests and to return GoogleTest `Result` from such tests. This required a fair amount of manual type conversion.

This adds two trait implementations behind an optional dependency on the `proptest` crate:

 * An implementation of 'IntoTestResult` allows easily converting the output of `TestRunner` into a GoogleTest `Result`.
 * An implementation of `From<TestAssertionFailure>` for `TestCaseError` allows easily using GoogleTest macros such as `verify_that!` inside `TestRunner::run`.

In particular, with this change, it is much easier to have property-based tests using `proptest` which do not panic on failure but rather communicate failures using `Result`, as is idiomatic in GoogleTest.