### PR TITLE
Add an explanation header to the difference summary

### DIFF
--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -111,10 +111,10 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                     which displays as a string which isn't equal to \"123\\n345\"
-                    Difference:
+                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
                      123
-                    +\x1B[1;31m234\x1B[0m
-                    -\x1B[1;34m345\x1B[0m
+                    -\x1B[1;31m234\x1B[0m
+                    +\x1B[1;32m345\x1B[0m
                 "
             ))))
         )

--- a/googletest/src/matchers/eq_deref_of_matcher.rs
+++ b/googletest/src/matchers/eq_deref_of_matcher.rs
@@ -88,8 +88,8 @@ where
             "which {}{}",
             &self.describe(self.matches(actual)),
             create_diff(
-                &format!("{:#?}", self.expected.deref()),
                 &format!("{:#?}", actual),
+                &format!("{:#?}", self.expected.deref()),
                 edit_distance::Mode::Exact,
             )
         )
@@ -138,12 +138,12 @@ mod tests {
             "
             Actual: Strukt { int: 123, string: \"something\" },
               which isn't equal to Strukt { int: 321, string: \"someone\" }
-            Difference:
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
              Strukt {
-            +\x1B[1;31m    int: 123,\x1B[0m
-            -\x1B[1;34m    int: 321,\x1B[0m
-            +\x1B[1;31m    string: \"something\",\x1B[0m
-            -\x1B[1;34m    string: \"someone\",\x1B[0m
+            -\x1B[1;31m    int: 123,\x1B[0m
+            +\x1B[1;32m    int: 321,\x1B[0m
+            -\x1B[1;31m    string: \"something\",\x1B[0m
+            +\x1B[1;32m    string: \"someone\",\x1B[0m
              }
             "})))
         )

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -109,12 +109,12 @@ impl<A: Debug + ?Sized, T: PartialEq<A> + Debug> Matcher for EqMatcher<A, T> {
                 // respectively actual_debug are not enclosed in ". The calls to
                 // is_multiline_string_debug above ensure that they are. So the calls cannot
                 // actually return None and unwrap() should not panic.
-                &to_display_output(&expected_debug).unwrap(),
                 &to_display_output(&actual_debug).unwrap(),
+                &to_display_output(&expected_debug).unwrap(),
                 edit_distance::Mode::Exact,
             )
         } else {
-            create_diff(&expected_debug, &actual_debug, edit_distance::Mode::Exact)
+            create_diff(&actual_debug, &expected_debug, edit_distance::Mode::Exact)
         };
 
         format!("which {description}{diff}")
@@ -178,12 +178,12 @@ mod tests {
             "
             Actual: Strukt { int: 123, string: \"something\" },
               which isn't equal to Strukt { int: 321, string: \"someone\" }
-            Difference:
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
              Strukt {
-            +\x1B[1;31m    int: 123,\x1B[0m
-            -\x1B[1;34m    int: 321,\x1B[0m
-            +\x1B[1;31m    string: \"something\",\x1B[0m
-            -\x1B[1;34m    string: \"someone\",\x1B[0m
+            -\x1B[1;31m    int: 123,\x1B[0m
+            +\x1B[1;32m    int: 321,\x1B[0m
+            -\x1B[1;31m    string: \"something\",\x1B[0m
+            +\x1B[1;32m    string: \"someone\",\x1B[0m
              }
             "})))
         )
@@ -200,12 +200,12 @@ mod tests {
             Expected: is equal to [1, 3, 4]
             Actual: [1, 2, 3],
               which isn't equal to [1, 3, 4]
-            Difference:
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
              [
                  1,
-            +\x1B[1;31m    2,\x1B[0m
+            -\x1B[1;31m    2,\x1B[0m
                  3,
-            -\x1B[1;34m    4,\x1B[0m
+            +\x1B[1;32m    4,\x1B[0m
              ]
             "})))
         )
@@ -222,12 +222,12 @@ mod tests {
             Expected: is equal to [1, 3, 5]
             Actual: [1, 2, 3, 4, 5],
               which isn't equal to [1, 3, 5]
-            Difference:
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
              [
                  1,
-            +\x1B[1;31m    2,\x1B[0m
+            -\x1B[1;31m    2,\x1B[0m
                  3,
-            +\x1B[1;31m    4,\x1B[0m
+            -\x1B[1;31m    4,\x1B[0m
                  5,
              ]
             "})))
@@ -241,17 +241,17 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference:
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
              [
-            +\x1B[1;31m    1,\x1B[0m
-            +\x1B[1;31m    2,\x1B[0m
+            -\x1B[1;31m    1,\x1B[0m
+            -\x1B[1;31m    2,\x1B[0m
                  3,
                  4,
              \x1B[3m<---- 43 common lines omitted ---->\x1B[0m
                  48,
                  49,
-            -\x1B[1;34m    50,\x1B[0m
-            -\x1B[1;34m    51,\x1B[0m
+            +\x1B[1;32m    50,\x1B[0m
+            +\x1B[1;32m    51,\x1B[0m
              ]"})))
         )
     }
@@ -263,17 +263,17 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference:
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
              [
-            +\x1B[1;31m    1,\x1B[0m
-            +\x1B[1;31m    2,\x1B[0m
+            -\x1B[1;31m    1,\x1B[0m
+            -\x1B[1;31m    2,\x1B[0m
                  3,
                  4,
                  5,
                  6,
                  7,
-            -\x1B[1;34m    8,\x1B[0m
-            -\x1B[1;34m    9,\x1B[0m
+            +\x1B[1;32m    8,\x1B[0m
+            +\x1B[1;32m    9,\x1B[0m
              ]"})))
         )
     }
@@ -285,14 +285,14 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference:
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
              [
                  1,
              \x1B[3m<---- 46 common lines omitted ---->\x1B[0m
                  48,
                  49,
-            -\x1B[1;34m    50,\x1B[0m
-            -\x1B[1;34m    51,\x1B[0m
+            +\x1B[1;32m    50,\x1B[0m
+            +\x1B[1;32m    51,\x1B[0m
              ]"})))
         )
     }
@@ -304,10 +304,10 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference:
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
              [
-            +\x1B[1;31m    1,\x1B[0m
-            +\x1B[1;31m    2,\x1B[0m
+            -\x1B[1;31m    1,\x1B[0m
+            -\x1B[1;31m    2,\x1B[0m
                  3,
                  4,
              \x1B[3m<---- 46 common lines omitted ---->\x1B[0m
@@ -357,8 +357,8 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                  First line
-                +\x1B[1;31mSecond line\x1B[0m
-                -\x1B[1;34mSecond lines\x1B[0m
+                -\x1B[1;31mSecond line\x1B[0m
+                +\x1B[1;32mSecond lines\x1B[0m
                  Third line
                 "
             ))))
@@ -378,7 +378,7 @@ mod tests {
             ))
         );
 
-        verify_that!(result, err(displays_as(not(contains_substring("Difference:")))))
+        verify_that!(result, err(displays_as(not(contains_substring("Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):")))))
     }
 
     #[test]
@@ -394,6 +394,6 @@ mod tests {
             eq("First line")
         );
 
-        verify_that!(result, err(displays_as(not(contains_substring("Difference:")))))
+        verify_that!(result, err(displays_as(not(contains_substring("Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):")))))
     }
 }

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -544,9 +544,9 @@ impl Configuration {
                 // TODO(b/287632452): Also consider improving the output in MatchMode::Contains
                 // when the substring begins or ends in the middle of a line of the actual
                 // value.
-                create_diff(expected, actual, self.mode.to_diff_mode())
+                create_diff(actual, expected, self.mode.to_diff_mode())
             }
-            MatchMode::EndsWith => create_diff_reversed(expected, actual, self.mode.to_diff_mode()),
+            MatchMode::EndsWith => create_diff_reversed(actual, expected, self.mode.to_diff_mode()),
         };
 
         format!("{default_explanation}\n{diff}",)
@@ -974,8 +974,8 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                  First line
-                +\x1B[1;31mSecond line\x1B[0m
-                -\x1B[1;34mSecond lines\x1B[0m
+                -\x1B[1;31mSecond line\x1B[0m
+                +\x1B[1;32mSecond lines\x1B[0m
                  Third line
                 "
             ))))
@@ -1007,8 +1007,8 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    +\x1B[1;31mSecond line\x1B[0m
-                    -\x1B[1;34mSecond lines\x1B[0m
+                    -\x1B[1;31mSecond line\x1B[0m
+                    +\x1B[1;32mSecond lines\x1B[0m
                      Third line
                      \x1B[3m<---- remaining lines omitted ---->\x1B[0m
                 "
@@ -1040,8 +1040,8 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    +\x1B[1;31mSecond line\x1B[0m
-                    -\x1B[1;34mSecond lines\x1B[0m
+                    -\x1B[1;31mSecond line\x1B[0m
+                    +\x1B[1;32mSecond lines\x1B[0m
                      \x1B[3m<---- remaining lines omitted ---->\x1B[0m
                 "
             ))))
@@ -1072,11 +1072,11 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference:
+                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
                      \x1B[3m<---- remaining lines omitted ---->\x1B[0m
                      Second line
-                    -\x1B[1;34mThird lines\x1B[0m
-                    +\x1B[1;31mThird line\x1B[0m
+                    +\x1B[1;32mThird lines\x1B[0m
+                    -\x1B[1;31mThird line\x1B[0m
                      Fourth line
                 "
             ))))
@@ -1109,11 +1109,11 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference:
+                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
                      \x1B[3m<---- remaining lines omitted ---->\x1B[0m
                      Second line
-                    -\x1B[1;34mThird lines\x1B[0m
-                    +\x1B[1;31mThird line\x1B[0m
+                    +\x1B[1;32mThird lines\x1B[0m
+                    -\x1B[1;31mThird line\x1B[0m
                      Fourth line
                      \x1B[3m<---- remaining lines omitted ---->\x1B[0m"
             ))))
@@ -1146,15 +1146,15 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference:
+                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
                      \x1B[3m<---- remaining lines omitted ---->\x1B[0m
-                    -\x1B[1;34mline\x1B[0m
-                    +\x1B[1;31mSecond line\x1B[0m
+                    +\x1B[1;32mline\x1B[0m
+                    -\x1B[1;31mSecond line\x1B[0m
                      Third line
-                    -\x1B[1;34mFoorth line\x1B[0m
-                    +\x1B[1;31mFourth line\x1B[0m
-                    -\x1B[1;34mFifth\x1B[0m
-                    +\x1B[1;31mFifth line\x1B[0m
+                    +\x1B[1;32mFoorth line\x1B[0m
+                    -\x1B[1;31mFourth line\x1B[0m
+                    +\x1B[1;32mFifth\x1B[0m
+                    -\x1B[1;31mFifth line\x1B[0m
                      \x1B[3m<---- remaining lines omitted ---->\x1B[0m
                 "
             ))))
@@ -1186,10 +1186,10 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    +\x1B[1;31mSecond line\x1B[0m
-                    -\x1B[1;34mSecond lines\x1B[0m
+                    -\x1B[1;31mSecond line\x1B[0m
+                    +\x1B[1;32mSecond lines\x1B[0m
                      Third line
-                    +\x1B[1;31mFourth line\x1B[0m
+                    -\x1B[1;31mFourth line\x1B[0m
                 "
             ))))
         )
@@ -1207,7 +1207,7 @@ mod tests {
             ))
         );
 
-        verify_that!(result, err(displays_as(not(contains_substring("Difference:")))))
+        verify_that!(result, err(displays_as(not(contains_substring("Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):")))))
     }
 
     #[test]
@@ -1223,6 +1223,6 @@ mod tests {
             starts_with("Second line")
         );
 
-        verify_that!(result, err(displays_as(not(contains_substring("Difference:")))))
+        verify_that!(result, err(displays_as(not(contains_substring("Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):")))))
     }
 }


### PR DESCRIPTION
This will produce the following result, which makes more obvious what colors and +/- means.

![Screenshot from 2023-07-07 14-02-05](https://github.com/google/googletest-rust/assets/2683744/484abc7c-5d3e-498d-884a-f1782145afce)

This triggered the following refactoring:
* Don't rely on `left` and `right` to describe the argument of `edit_list`. 
* Accept `actual` as first argument and `expected` as second (like in `verify_that!`)
* Use Red vs Green instead of Red vs Blue for better contrast.
* Use `-` for `actual` and `+` for `expected`. In a TTD process, expected is the ground truth that the code should generate, hence it reads as the recommendation: `The code should remove the `-` lines and generate the `+` lines.
