### PR TITLE
Implement BufferedSummary to collect the Edit

### DIFF
--- a/googletest/src/matcher_support/summarize_diff.rs
+++ b/googletest/src/matcher_support/summarize_diff.rs
@@ -49,7 +49,7 @@ pub(crate) fn create_diff(
             "\nDifference({} / {}):{}",
             LineStyle::extra_actual_style().style("actual"),
             LineStyle::extra_expected_style().style("expected"),
-            edit_list_summary(&edit_list)
+            edit_list.into_iter().collect::<BufferedSummary>(),
         )
         .into(),
         edit_distance::Difference::Unrelated => "".into(),
@@ -85,7 +85,7 @@ pub(crate) fn create_diff_reversed(
                 "\nDifference({} / {}):{}",
                 LineStyle::extra_actual_style().style("actual"),
                 LineStyle::extra_expected_style().style("expected"),
-                edit_list_summary(&edit_list)
+                edit_list.into_iter().collect::<BufferedSummary>(),
             )
             .into()
         }
@@ -93,65 +93,130 @@ pub(crate) fn create_diff_reversed(
     }
 }
 
-fn edit_list_summary(edit_list: &[edit_distance::Edit<&str>]) -> String {
-    let mut summary = String::new();
-    // Use to collect common line and compress them.
-    let mut common_line_buffer = vec![];
-    for edit in edit_list {
-        let (style, line) = match edit {
-            edit_distance::Edit::Both(same) => {
-                common_line_buffer.push(*same);
-                continue;
-            }
-            edit_distance::Edit::ExtraActual(actual) => (LineStyle::extra_actual_style(), *actual),
-            edit_distance::Edit::ExtraExpected(expected) => {
-                (LineStyle::extra_expected_style(), *expected)
-            }
-            edit_distance::Edit::AdditionalActual => {
-                (LineStyle::comment_style(), "<---- remaining lines omitted ---->")
-            }
-        };
-        summary.push_str(&compress_common_lines(std::mem::take(&mut common_line_buffer)));
-
-        write!(&mut summary, "\n{}", style.style(line)).unwrap();
+struct BufferedSummary<'a> {
+    summary: String,
+    buffer: Buffer<'a>,
+}
+impl<'a> BufferedSummary<'a> {
+    fn new() -> Self {
+        Self { summary: String::new(), buffer: Buffer::CommonLineBuffer(vec![]) }
     }
-    summary.push_str(&compress_common_lines(common_line_buffer));
 
-    summary
+    fn feed_common_lines(&mut self, common_line: &'a str) {
+        let Buffer::CommonLineBuffer(ref mut common_lines) = self.buffer;
+        common_lines.push(common_line);
+    }
+    fn feed_extra_actual(&mut self, extra_actual: &'a str) {
+        self.buffer.flush(&mut self.summary).unwrap();
+        write!(&mut self.summary, "\n{}", LineStyle::extra_actual_style().style(extra_actual))
+            .unwrap();
+    }
+
+    fn feed_extra_expected(&mut self, extra_expected: &str) {
+        self.flush_buffer();
+        write!(&mut self.summary, "\n{}", LineStyle::extra_expected_style().style(extra_expected))
+            .unwrap();
+    }
+
+    fn feed_additional_actual(&mut self) {
+        self.flush_buffer();
+        write!(
+            &mut self.summary,
+            "\n{}",
+            LineStyle::comment_style().style("<---- remaining lines omitted ---->")
+        )
+        .unwrap();
+    }
+
+    fn flush_buffer(&mut self) {
+        self.buffer.flush(&mut self.summary).unwrap();
+    }
 }
 
-// The number of the lines kept before and after the compressed lines.
-const COMMON_LINES_CONTEXT_SIZE: usize = 2;
-
-fn compress_common_lines(common_lines: Vec<&str>) -> String {
-    if common_lines.len() <= 2 * COMMON_LINES_CONTEXT_SIZE + 1 {
-        let mut all_lines = String::new();
-        for line in common_lines {
-            write!(&mut all_lines, "\n{}", LineStyle::unchanged_style().style(line)).unwrap();
+impl<'a> FromIterator<edit_distance::Edit<&'a str>> for BufferedSummary<'a> {
+    fn from_iter<T: IntoIterator<Item = edit_distance::Edit<&'a str>>>(iter: T) -> Self {
+        let mut buffered_summary = BufferedSummary::new();
+        for edit in iter {
+            match edit {
+                edit_distance::Edit::Both(same) => {
+                    buffered_summary.feed_common_lines(same);
+                }
+                edit_distance::Edit::ExtraActual(actual) => {
+                    buffered_summary.feed_extra_actual(actual);
+                }
+                edit_distance::Edit::ExtraExpected(expected) => {
+                    buffered_summary.feed_extra_expected(expected);
+                }
+                edit_distance::Edit::AdditionalActual => {
+                    buffered_summary.feed_additional_actual();
+                }
+            };
         }
-        return all_lines;
+        buffered_summary.flush_buffer();
+
+        buffered_summary
+    }
+}
+
+impl<'a> Display for BufferedSummary<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !matches!(self.buffer, Buffer::CommonLineBuffer(ref b) if b.is_empty()) {
+            panic!("Buffer is not empty. This is a bug in gtest_rust.")
+        }
+        self.summary.fmt(f)
+    }
+}
+
+// This needs to be an enum as there will be in a follow-up new types of buffer, most likely actual and expected lines, to be compared with expected and actual lines for line to line comparison.
+enum Buffer<'a> {
+    CommonLineBuffer(Vec<&'a str>),
+}
+
+impl<'a> Buffer<'a> {
+    fn flush(&mut self, writer: impl std::fmt::Write) -> std::fmt::Result {
+        match self {
+            Buffer::CommonLineBuffer(common_lines) => {
+                Self::flush_common_lines(std::mem::take(common_lines), writer)?
+            }
+        };
+        Ok(())
     }
 
-    let mut truncated_lines = String::new();
+    fn flush_common_lines(
+        common_lines: Vec<&'a str>,
+        mut writer: impl std::fmt::Write,
+    ) -> std::fmt::Result {
+        // The number of the lines kept before and after the compressed lines.
+        const COMMON_LINES_CONTEXT_SIZE: usize = 2;
 
-    for line in &common_lines[0..COMMON_LINES_CONTEXT_SIZE] {
-        write!(&mut truncated_lines, "\n{}", LineStyle::unchanged_style().style(line)).unwrap();
+        if common_lines.len() <= 2 * COMMON_LINES_CONTEXT_SIZE + 1 {
+            for line in common_lines {
+                write!(writer, "\n{}", LineStyle::unchanged_style().style(line))?;
+            }
+            return Ok(());
+        }
+
+        for line in &common_lines[0..COMMON_LINES_CONTEXT_SIZE] {
+            write!(writer, "\n{}", LineStyle::unchanged_style().style(line)).unwrap();
+        }
+
+        write!(
+            writer,
+            "\n{}",
+            LineStyle::comment_style().style(&format!(
+                "<---- {} common lines omitted ---->",
+                common_lines.len() - 2 * COMMON_LINES_CONTEXT_SIZE
+            )),
+        )
+        .unwrap();
+
+        for line in
+            &common_lines[common_lines.len() - COMMON_LINES_CONTEXT_SIZE..common_lines.len()]
+        {
+            write!(writer, "\n{}", LineStyle::unchanged_style().style(line))?;
+        }
+        Ok(())
     }
-
-    write!(
-        &mut truncated_lines,
-        "\n{}",
-        LineStyle::comment_style().style(&format!(
-            "<---- {} common lines omitted ---->",
-            common_lines.len() - 2 * COMMON_LINES_CONTEXT_SIZE
-        )),
-    )
-    .unwrap();
-
-    for line in &common_lines[common_lines.len() - COMMON_LINES_CONTEXT_SIZE..common_lines.len()] {
-        write!(&mut truncated_lines, "\n{}", LineStyle::unchanged_style().style(line)).unwrap();
-    }
-    truncated_lines
 }
 
 struct LineStyle {


### PR DESCRIPTION
Refactor `sumarize_diff.rs` by encapsulating the `summary` along with the `buffer`.

This PR does not provide much value of its own, but will make it possible to extend the `buffer` to represent different types. This is necessary to display difference highlights between extra actual and extra expected.