### PR TITLE
Rename the enum variants of `MatcherResult` to `Match` and `NoMatch`.

### DIFF
--- a/googletest/crate_docs.md
+++ b/googletest/crate_docs.md
@@ -179,18 +179,18 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
 
     fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
         if self.expected == *actual {
-            MatcherResult::Matches
+            MatcherResult::Match
         } else {
-            MatcherResult::DoesNotMatch
+            MatcherResult::NoMatch
         }
     }
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
+            MatcherResult::Match => {
                 format!("is equal to {:?} the way I define it", self.expected)
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!("isn't equal to {:?} the way I define it", self.expected)
             }
         }
@@ -213,18 +213,18 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
  #
  #    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
  #        if self.expected == *actual {
- #            MatcherResult::Matches
+ #            MatcherResult::Match
  #        } else {
- #            MatcherResult::DoesNotMatch
+ #            MatcherResult::NoMatch
  #        }
  #    }
  #
  #    fn describe(&self, matcher_result: MatcherResult) -> String {
  #        match matcher_result {
- #            MatcherResult::Matches => {
+ #            MatcherResult::Match => {
  #                format!("is equal to {:?} the way I define it", self.expected)
  #            }
- #            MatcherResult::DoesNotMatch => {
+ #            MatcherResult::NoMatch => {
  #                format!("isn't equal to {:?} the way I define it", self.expected)
  #            }
  #        }
@@ -252,18 +252,18 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
 #
 #    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
 #        if self.expected == *actual {
-#            MatcherResult::Matches
+#            MatcherResult::Match
 #        } else {
-#            MatcherResult::DoesNotMatch
+#            MatcherResult::NoMatch
 #        }
 #    }
 #
 #    fn describe(&self, matcher_result: MatcherResult) -> String {
 #        match matcher_result {
-#            MatcherResult::Matches => {
+#            MatcherResult::Match => {
 #                format!("is equal to {:?} the way I define it", self.expected)
 #            }
-#            MatcherResult::DoesNotMatch => {
+#            MatcherResult::NoMatch => {
 #                format!("isn't equal to {:?} the way I define it", self.expected)
 #            }
 #        }

--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -355,8 +355,8 @@ pub mod internal {
         source_location: SourceLocation,
     ) -> Result<(), TestAssertionFailure> {
         match expected.matches(actual) {
-            MatcherResult::Matches => Ok(()),
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::Match => Ok(()),
+            MatcherResult::NoMatch => {
                 Err(create_assertion_failure(&expected, actual, actual_expr, source_location))
             }
         }

--- a/googletest/src/matcher.rs
+++ b/googletest/src/matcher.rs
@@ -225,7 +225,7 @@ Expected: {}
 Actual: {actual_formatted},
   {}
 {source_location}",
-        matcher.describe(MatcherResult::Matches),
+        matcher.describe(MatcherResult::Match),
         matcher.explain_match(actual),
     ))
 }
@@ -234,28 +234,32 @@ Actual: {actual_formatted},
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum MatcherResult {
     /// The actual value matches according to the [`Matcher`] definition.
-    Matches,
+    Match,
     /// The actual value does not match according to the [`Matcher`] definition.
-    DoesNotMatch,
+    NoMatch,
 }
 
 impl From<bool> for MatcherResult {
     fn from(b: bool) -> Self {
-        if b { MatcherResult::Matches } else { MatcherResult::DoesNotMatch }
+        if b {
+            MatcherResult::Match
+        } else {
+            MatcherResult::NoMatch
+        }
     }
 }
 
 impl From<MatcherResult> for bool {
     fn from(matcher_result: MatcherResult) -> Self {
         match matcher_result {
-            MatcherResult::Matches => true,
-            MatcherResult::DoesNotMatch => false,
+            MatcherResult::Match => true,
+            MatcherResult::NoMatch => false,
         }
     }
 }
 
 impl MatcherResult {
-    /// Returns `true` if `self` is [`MatcherResult::Matches`], otherwise
+    /// Returns `true` if `self` is [`MatcherResult::Match`], otherwise
     /// `false`.
     ///
     /// This delegates to `Into<bool>` but coerce the return type to `bool`

--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -92,13 +92,13 @@ pub mod internal {
         fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
             for component in &self.components {
                 match component.matches(actual) {
-                    MatcherResult::DoesNotMatch => {
-                        return MatcherResult::DoesNotMatch;
+                    MatcherResult::NoMatch => {
+                        return MatcherResult::NoMatch;
                     }
-                    MatcherResult::Matches => {}
+                    MatcherResult::Match => {}
                 }
             }
-            MatcherResult::Matches
+            MatcherResult::Match
         }
 
         fn explain_match(&self, actual: &Self::ActualT) -> String {
@@ -161,7 +161,7 @@ mod tests {
         let matcher: internal::AllMatcher<String, 2> = all!(first_matcher, second_matcher);
 
         verify_that!(
-            matcher.describe(MatcherResult::Matches),
+            matcher.describe(MatcherResult::Match),
             eq(indoc!(
                 "
                 has all the following properties:
@@ -176,7 +176,7 @@ mod tests {
         let first_matcher = starts_with("A");
         let matcher: internal::AllMatcher<String, 1> = all!(first_matcher);
 
-        verify_that!(matcher.describe(MatcherResult::Matches), eq("starts with prefix \"A\""))
+        verify_that!(matcher.describe(MatcherResult::Match), eq("starts with prefix \"A\""))
     }
 
     #[test]

--- a/googletest/src/matchers/anything_matcher.rs
+++ b/googletest/src/matchers/anything_matcher.rs
@@ -39,13 +39,13 @@ impl<T: Debug + ?Sized> Matcher for Anything<T> {
     type ActualT = T;
 
     fn matches(&self, _: &T) -> MatcherResult {
-        MatcherResult::Matches
+        MatcherResult::Match
     }
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => "is anything".to_string(),
-            MatcherResult::DoesNotMatch => "never matches".to_string(),
+            MatcherResult::Match => "is anything".to_string(),
+            MatcherResult::NoMatch => "never matches".to_string(),
         }
     }
 }

--- a/googletest/src/matchers/char_count_matcher.rs
+++ b/googletest/src/matchers/char_count_matcher.rs
@@ -73,16 +73,16 @@ impl<T: Debug + ?Sized + AsRef<str>, E: Matcher<ActualT = usize>> Matcher for Ch
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
+            MatcherResult::Match => {
                 format!(
                     "has character count, which {}",
-                    self.expected.describe(MatcherResult::Matches)
+                    self.expected.describe(MatcherResult::Match)
                 )
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!(
                     "has character count, which {}",
-                    self.expected.describe(MatcherResult::DoesNotMatch)
+                    self.expected.describe(MatcherResult::NoMatch)
                 )
             }
         }

--- a/googletest/src/matchers/conjunction_matcher.rs
+++ b/googletest/src/matchers/conjunction_matcher.rs
@@ -38,23 +38,23 @@ where
 
     fn matches(&self, actual: &M1::ActualT) -> MatcherResult {
         match (self.m1.matches(actual), self.m2.matches(actual)) {
-            (MatcherResult::Matches, MatcherResult::Matches) => MatcherResult::Matches,
-            _ => MatcherResult::DoesNotMatch,
+            (MatcherResult::Match, MatcherResult::Match) => MatcherResult::Match,
+            _ => MatcherResult::NoMatch,
         }
     }
 
     fn explain_match(&self, actual: &M1::ActualT) -> String {
         match (self.m1.matches(actual), self.m2.matches(actual)) {
-            (MatcherResult::Matches, MatcherResult::Matches) => {
+            (MatcherResult::Match, MatcherResult::Match) => {
                 format!(
                     "{} and\n  {}",
                     self.m1.explain_match(actual),
                     self.m2.explain_match(actual)
                 )
             }
-            (MatcherResult::DoesNotMatch, MatcherResult::Matches) => self.m1.explain_match(actual),
-            (MatcherResult::Matches, MatcherResult::DoesNotMatch) => self.m2.explain_match(actual),
-            (MatcherResult::DoesNotMatch, MatcherResult::DoesNotMatch) => {
+            (MatcherResult::NoMatch, MatcherResult::Match) => self.m1.explain_match(actual),
+            (MatcherResult::Match, MatcherResult::NoMatch) => self.m2.explain_match(actual),
+            (MatcherResult::NoMatch, MatcherResult::NoMatch) => {
                 format!(
                     "{} and\n  {}",
                     self.m1.explain_match(actual),

--- a/googletest/src/matchers/container_eq_matcher.rs
+++ b/googletest/src/matchers/container_eq_matcher.rs
@@ -120,8 +120,8 @@ where
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is equal to {:?}", self.expected),
-            MatcherResult::DoesNotMatch => format!("isn't equal to {:?}", self.expected),
+            MatcherResult::Match => format!("is equal to {:?}", self.expected),
+            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected),
         }
     }
 }
@@ -265,21 +265,21 @@ mod tests {
     }
 
     #[test]
-    fn container_eq_matches_owned_vec_of_owned_strings_with_slice_of_string_references()
-    -> Result<()> {
+    fn container_eq_matches_owned_vec_of_owned_strings_with_slice_of_string_references(
+    ) -> Result<()> {
         let vector = vec!["A string".to_string(), "Another string".to_string()];
         verify_that!(vector, container_eq(["A string", "Another string"]))
     }
 
     #[test]
-    fn container_eq_matches_owned_vec_of_owned_strings_with_shorter_slice_of_string_references()
-    -> Result<()> {
+    fn container_eq_matches_owned_vec_of_owned_strings_with_shorter_slice_of_string_references(
+    ) -> Result<()> {
         let actual = vec!["A string".to_string(), "Another string".to_string()];
         let matcher = container_eq(["A string"]);
 
         let result = matcher.matches(&actual);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]

--- a/googletest/src/matchers/contains_matcher.rs
+++ b/googletest/src/matchers/contains_matcher.rs
@@ -92,10 +92,10 @@ where
         } else {
             for v in actual.into_iter() {
                 if self.inner.matches(v).into() {
-                    return MatcherResult::Matches;
+                    return MatcherResult::Match;
                 }
             }
-            MatcherResult::DoesNotMatch
+            MatcherResult::NoMatch
         }
     }
 
@@ -110,22 +110,22 @@ where
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match (matcher_result, &self.count) {
-            (MatcherResult::Matches, Some(count)) => format!(
+            (MatcherResult::Match, Some(count)) => format!(
                 "contains n elements which {}\n  where n {}",
-                self.inner.describe(MatcherResult::Matches),
-                count.describe(MatcherResult::Matches)
+                self.inner.describe(MatcherResult::Match),
+                count.describe(MatcherResult::Match)
             ),
-            (MatcherResult::DoesNotMatch, Some(count)) => format!(
+            (MatcherResult::NoMatch, Some(count)) => format!(
                 "doesn't contain n elements which {}\n  where n {}",
-                self.inner.describe(MatcherResult::Matches),
-                count.describe(MatcherResult::Matches)
+                self.inner.describe(MatcherResult::Match),
+                count.describe(MatcherResult::Match)
             ),
-            (MatcherResult::Matches, None) => format!(
+            (MatcherResult::Match, None) => format!(
                 "contains at least one element which {}",
-                self.inner.describe(MatcherResult::Matches)
+                self.inner.describe(MatcherResult::Match)
             ),
-            (MatcherResult::DoesNotMatch, None) => {
-                format!("contains no element which {}", self.inner.describe(MatcherResult::Matches))
+            (MatcherResult::NoMatch, None) => {
+                format!("contains no element which {}", self.inner.describe(MatcherResult::Match))
             }
         }
     }
@@ -159,7 +159,7 @@ mod tests {
 
         let result = matcher.matches(&vec![1]);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -168,7 +168,7 @@ mod tests {
 
         let result = matcher.matches(&vec![1]);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
 
         let result = matcher.matches(&[0, 1]);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -186,7 +186,7 @@ mod tests {
 
         let result = matcher.matches(&[0]);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -195,7 +195,7 @@ mod tests {
 
         let result = matcher.matches(&[]);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -204,7 +204,7 @@ mod tests {
 
         let result = matcher.matches(&[1, 1]);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -213,7 +213,7 @@ mod tests {
 
         let result = matcher.matches(&[0, 1]);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -222,7 +222,7 @@ mod tests {
 
         let result = matcher.matches(&[1, 1]);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -230,7 +230,7 @@ mod tests {
         let matcher: ContainsMatcher<Vec<i32>, _> = contains(eq(1));
 
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("contains at least one element which is equal to 1")
         )
     }
@@ -240,7 +240,7 @@ mod tests {
         let matcher: ContainsMatcher<Vec<i32>, _> = contains(eq(1)).times(eq(2));
 
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("contains n elements which is equal to 1\n  where n is equal to 2")
         )
     }

--- a/googletest/src/matchers/contains_regex_matcher.rs
+++ b/googletest/src/matchers/contains_regex_matcher.rs
@@ -79,10 +79,10 @@ impl<ActualT: AsRef<str> + Debug + ?Sized> Matcher for ContainsRegexMatcher<Actu
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
+            MatcherResult::Match => {
                 format!("contains the regular expression {:#?}", self.regex.as_str())
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!("doesn't contain the regular expression {:#?}", self.regex.as_str())
             }
         }
@@ -101,7 +101,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -110,7 +110,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -119,7 +119,7 @@ mod tests {
 
         let result = matcher.matches(&"Some value".to_string());
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -128,7 +128,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -141,7 +141,7 @@ mod tests {
         let matcher: ContainsRegexMatcher<&str> = contains_regex("\n");
 
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("contains the regular expression \"\\n\"")
         )
     }

--- a/googletest/src/matchers/disjunction_matcher.rs
+++ b/googletest/src/matchers/disjunction_matcher.rs
@@ -38,10 +38,8 @@ where
 
     fn matches(&self, actual: &M1::ActualT) -> MatcherResult {
         match (self.m1.matches(actual), self.m2.matches(actual)) {
-            (MatcherResult::DoesNotMatch, MatcherResult::DoesNotMatch) => {
-                MatcherResult::DoesNotMatch
-            }
-            _ => MatcherResult::Matches,
+            (MatcherResult::NoMatch, MatcherResult::NoMatch) => MatcherResult::NoMatch,
+            _ => MatcherResult::Match,
         }
     }
 

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -48,16 +48,13 @@ impl<T: Debug + Display, InnerMatcher: Matcher<ActualT = String>> Matcher
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
-                format!(
-                    "displays as a string which {}",
-                    self.inner.describe(MatcherResult::Matches)
-                )
+            MatcherResult::Match => {
+                format!("displays as a string which {}", self.inner.describe(MatcherResult::Match))
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!(
                     "doesn't display as a string which {}",
-                    self.inner.describe(MatcherResult::Matches)
+                    self.inner.describe(MatcherResult::Match)
                 )
             }
         }

--- a/googletest/src/matchers/each_matcher.rs
+++ b/googletest/src/matchers/each_matcher.rs
@@ -81,10 +81,10 @@ where
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         for element in actual {
             if !self.inner.matches(element).into_bool() {
-                return MatcherResult::DoesNotMatch;
+                return MatcherResult::NoMatch;
             }
         }
-        MatcherResult::Matches
+        MatcherResult::Match
     }
 
     fn explain_match(&self, actual: &ActualT) -> String {
@@ -95,7 +95,7 @@ where
             }
         }
         if non_matching_elements.is_empty() {
-            return format!("whose each element {}", self.inner.describe(MatcherResult::Matches));
+            return format!("whose each element {}", self.inner.describe(MatcherResult::Match));
         }
         if non_matching_elements.len() == 1 {
             let (idx, element, explanation) = non_matching_elements.remove(0);
@@ -117,14 +117,11 @@ where
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
-                format!(
-                    "only contains elements that {}",
-                    self.inner.describe(MatcherResult::Matches)
-                )
+            MatcherResult::Match => {
+                format!("only contains elements that {}", self.inner.describe(MatcherResult::Match))
             }
-            MatcherResult::DoesNotMatch => {
-                format!("contains no element that {}", self.inner.describe(MatcherResult::Matches))
+            MatcherResult::NoMatch => {
+                format!("contains no element that {}", self.inner.describe(MatcherResult::Match))
             }
         }
     }

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -123,13 +123,13 @@ pub mod internal {
             let mut zipped_iterator = zip(actual.into_iter(), self.elements.iter());
             for (a, e) in zipped_iterator.by_ref() {
                 if !e.matches(a).into_bool() {
-                    return MatcherResult::DoesNotMatch;
+                    return MatcherResult::NoMatch;
                 }
             }
             if !zipped_iterator.has_size_mismatch() {
-                MatcherResult::Matches
+                MatcherResult::Match
             } else {
-                MatcherResult::DoesNotMatch
+                MatcherResult::NoMatch
             }
         }
 
@@ -164,7 +164,7 @@ pub mod internal {
                 &self
                     .elements
                     .iter()
-                    .map(|matcher| matcher.describe(MatcherResult::Matches))
+                    .map(|matcher| matcher.describe(MatcherResult::Match))
                     .collect::<Description>()
                     .enumerate()
                     .indent()

--- a/googletest/src/matchers/eq_deref_of_matcher.rs
+++ b/googletest/src/matchers/eq_deref_of_matcher.rs
@@ -78,8 +78,8 @@ where
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is equal to {:?}", self.expected),
-            MatcherResult::DoesNotMatch => format!("isn't equal to {:?}", self.expected),
+            MatcherResult::Match => format!("is equal to {:?}", self.expected),
+            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected),
         }
     }
 

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -91,8 +91,8 @@ impl<A: Debug + ?Sized, T: PartialEq<A> + Debug> Matcher for EqMatcher<A, T> {
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is equal to {:?}", self.expected),
-            MatcherResult::DoesNotMatch => format!("isn't equal to {:?}", self.expected),
+            MatcherResult::Match => format!("is equal to {:?}", self.expected),
+            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected),
         }
     }
 

--- a/googletest/src/matchers/err_matcher.rs
+++ b/googletest/src/matchers/err_matcher.rs
@@ -53,7 +53,7 @@ impl<T: Debug, E: Debug, InnerMatcherT: Matcher<ActualT = E>> Matcher
     type ActualT = std::result::Result<T, E>;
 
     fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
-        actual.as_ref().err().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::DoesNotMatch)
+        actual.as_ref().err().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::NoMatch)
     }
 
     fn explain_match(&self, actual: &Self::ActualT) -> String {
@@ -65,13 +65,13 @@ impl<T: Debug, E: Debug, InnerMatcherT: Matcher<ActualT = E>> Matcher
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
-                format!("is an error which {}", self.inner.describe(MatcherResult::Matches))
+            MatcherResult::Match => {
+                format!("is an error which {}", self.inner.describe(MatcherResult::Match))
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!(
                     "is a success or is an error containing a value which {}",
-                    self.inner.describe(MatcherResult::DoesNotMatch)
+                    self.inner.describe(MatcherResult::NoMatch)
                 )
             }
         }
@@ -92,7 +92,7 @@ mod tests {
 
         let result = matcher.matches(&value);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -102,7 +102,7 @@ mod tests {
 
         let result = matcher.matches(&value);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
 
         let result = matcher.matches(&value);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -139,9 +139,6 @@ mod tests {
             phantom_t: Default::default(),
             phantom_e: Default::default(),
         };
-        verify_that!(
-            matcher.describe(MatcherResult::Matches),
-            eq("is an error which is equal to 1")
-        )
+        verify_that!(matcher.describe(MatcherResult::Match), eq("is an error which is equal to 1"))
     }
 }

--- a/googletest/src/matchers/field_matcher.rs
+++ b/googletest/src/matchers/field_matcher.rs
@@ -171,7 +171,7 @@ pub mod internal {
             if let Some(value) = (self.field_accessor)(actual) {
                 self.inner.matches(value)
             } else {
-                MatcherResult::DoesNotMatch
+                MatcherResult::NoMatch
             }
         }
 

--- a/googletest/src/matchers/ge_matcher.rs
+++ b/googletest/src/matchers/ge_matcher.rs
@@ -93,8 +93,8 @@ impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is greater than or equal to {:?}", self.expected),
-            MatcherResult::DoesNotMatch => format!("is less than {:?}", self.expected),
+            MatcherResult::Match => format!("is greater than or equal to {:?}", self.expected),
+            MatcherResult::NoMatch => format!("is less than {:?}", self.expected),
         }
     }
 }
@@ -118,7 +118,7 @@ mod tests {
     fn ge_does_not_match_smaller_i32() -> Result<()> {
         let matcher = ge(10);
         let result = matcher.matches(&9);
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -130,7 +130,7 @@ mod tests {
     fn ge_does_not_match_lesser_str() -> Result<()> {
         let matcher = ge("z");
         let result = matcher.matches(&"a");
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]

--- a/googletest/src/matchers/gt_matcher.rs
+++ b/googletest/src/matchers/gt_matcher.rs
@@ -93,8 +93,8 @@ impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is greater than {:?}", self.expected),
-            MatcherResult::DoesNotMatch => format!("is less than or equal to {:?}", self.expected),
+            MatcherResult::Match => format!("is greater than {:?}", self.expected),
+            MatcherResult::NoMatch => format!("is less than or equal to {:?}", self.expected),
         }
     }
 }
@@ -118,14 +118,14 @@ mod tests {
     fn gt_does_not_match_equal_i32() -> Result<()> {
         let matcher = gt(10);
         let result = matcher.matches(&10);
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
     fn gt_does_not_match_lower_i32() -> Result<()> {
         let matcher = gt(-50);
         let result = matcher.matches(&-51);
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -137,7 +137,7 @@ mod tests {
     fn gt_does_not_match_lesser_str() -> Result<()> {
         let matcher = gt("B");
         let result = matcher.matches(&"A");
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -175,16 +175,13 @@ mod tests {
 
     #[test]
     fn gt_describe_matches() -> Result<()> {
-        verify_that!(
-            gt::<i32, i32>(232).describe(MatcherResult::Matches),
-            eq("is greater than 232")
-        )
+        verify_that!(gt::<i32, i32>(232).describe(MatcherResult::Match), eq("is greater than 232"))
     }
 
     #[test]
     fn gt_describe_does_not_match() -> Result<()> {
         verify_that!(
-            gt::<i32, i32>(232).describe(MatcherResult::DoesNotMatch),
+            gt::<i32, i32>(232).describe(MatcherResult::NoMatch),
             eq("is less than or equal to 232")
         )
     }

--- a/googletest/src/matchers/has_entry_matcher.rs
+++ b/googletest/src/matchers/has_entry_matcher.rs
@@ -83,7 +83,7 @@ impl<KeyT: Debug + Eq + Hash, ValueT: Debug, MatcherT: Matcher<ActualT = ValueT>
         if let Some(value) = actual.get(&self.key) {
             self.inner.matches(value)
         } else {
-            MatcherResult::DoesNotMatch
+            MatcherResult::NoMatch
         }
     }
 
@@ -102,16 +102,16 @@ impl<KeyT: Debug + Eq + Hash, ValueT: Debug, MatcherT: Matcher<ActualT = ValueT>
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!(
+            MatcherResult::Match => format!(
                 "contains key {:?}, which value {}",
                 self.key,
-                self.inner.describe(MatcherResult::Matches)
+                self.inner.describe(MatcherResult::Match)
             ),
-            MatcherResult::DoesNotMatch => format!(
+            MatcherResult::NoMatch => format!(
                 "doesn't contain key {:?} or contains key {:?}, which value {}",
                 self.key,
                 self.key,
-                self.inner.describe(MatcherResult::DoesNotMatch)
+                self.inner.describe(MatcherResult::NoMatch)
             ),
         }
     }

--- a/googletest/src/matchers/is_matcher.rs
+++ b/googletest/src/matchers/is_matcher.rs
@@ -46,15 +46,15 @@ impl<'a, ActualT: Debug, InnerMatcherT: Matcher<ActualT = ActualT>> Matcher
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!(
+            MatcherResult::Match => format!(
                 "is {} which {}",
                 self.description,
-                self.inner.describe(MatcherResult::Matches)
+                self.inner.describe(MatcherResult::Match)
             ),
-            MatcherResult::DoesNotMatch => format!(
+            MatcherResult::NoMatch => format!(
                 "is not {} which {}",
                 self.description,
-                self.inner.describe(MatcherResult::Matches)
+                self.inner.describe(MatcherResult::Match)
             ),
         }
     }

--- a/googletest/src/matchers/le_matcher.rs
+++ b/googletest/src/matchers/le_matcher.rs
@@ -93,8 +93,8 @@ impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is less than or equal to {:?}", self.expected),
-            MatcherResult::DoesNotMatch => format!("is greater than {:?}", self.expected),
+            MatcherResult::Match => format!("is less than or equal to {:?}", self.expected),
+            MatcherResult::NoMatch => format!("is greater than {:?}", self.expected),
         }
     }
 }
@@ -118,7 +118,7 @@ mod tests {
     fn le_does_not_match_bigger_i32() -> Result<()> {
         let matcher = le(0);
         let result = matcher.matches(&1);
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -130,7 +130,7 @@ mod tests {
     fn le_does_not_match_bigger_str() -> Result<()> {
         let matcher = le("a");
         let result = matcher.matches(&"z");
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]

--- a/googletest/src/matchers/len_matcher.rs
+++ b/googletest/src/matchers/len_matcher.rs
@@ -70,11 +70,11 @@ where
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
-                format!("has length, which {}", self.expected.describe(MatcherResult::Matches))
+            MatcherResult::Match => {
+                format!("has length, which {}", self.expected.describe(MatcherResult::Match))
             }
-            MatcherResult::DoesNotMatch => {
-                format!("has length, which {}", self.expected.describe(MatcherResult::DoesNotMatch))
+            MatcherResult::NoMatch => {
+                format!("has length, which {}", self.expected.describe(MatcherResult::NoMatch))
             }
         }
     }

--- a/googletest/src/matchers/lt_matcher.rs
+++ b/googletest/src/matchers/lt_matcher.rs
@@ -93,8 +93,8 @@ impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is less than {:?}", self.expected),
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::Match => format!("is less than {:?}", self.expected),
+            MatcherResult::NoMatch => {
                 format!("is greater than or equal to {:?}", self.expected)
             }
         }
@@ -120,14 +120,14 @@ mod tests {
     fn lt_does_not_match_equal_i32() -> Result<()> {
         let matcher = lt(10);
         let result = matcher.matches(&10);
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
     fn lt_does_not_match_lower_i32() -> Result<()> {
         let matcher = lt(-50);
         let result = matcher.matches(&50);
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -139,7 +139,7 @@ mod tests {
     fn lt_does_not_match_bigger_str() -> Result<()> {
         let matcher = lt("ab");
         let result = matcher.matches(&"az");
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]

--- a/googletest/src/matchers/matches_regex_matcher.rs
+++ b/googletest/src/matchers/matches_regex_matcher.rs
@@ -96,10 +96,10 @@ where
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
+            MatcherResult::Match => {
                 format!("matches the regular expression {:#?}", self.pattern.deref())
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!("doesn't match the regular expression {:#?}", self.pattern.deref())
             }
         }
@@ -118,7 +118,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -127,7 +127,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -136,7 +136,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -145,7 +145,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -154,7 +154,7 @@ mod tests {
 
         let result = matcher.matches(&"Some value".to_string());
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -163,7 +163,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -172,7 +172,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -181,7 +181,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
 
         let result = matcher.matches("Some value");
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -203,7 +203,7 @@ mod tests {
         let matcher: MatchesRegexMatcher<&str, _> = matches_regex("\n");
 
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("matches the regular expression \"\\n\"")
         )
     }

--- a/googletest/src/matchers/near_matcher.rs
+++ b/googletest/src/matchers/near_matcher.rs
@@ -168,23 +168,23 @@ impl<T: Debug + Float> Matcher for NearMatcher<T> {
 
     fn matches(&self, actual: &T) -> MatcherResult {
         if self.nans_are_equal && self.expected.is_nan() && actual.is_nan() {
-            return MatcherResult::Matches;
+            return MatcherResult::Match;
         }
 
         let delta = *actual - self.expected;
         if delta >= -self.max_abs_error && delta <= self.max_abs_error {
-            MatcherResult::Matches
+            MatcherResult::Match
         } else {
-            MatcherResult::DoesNotMatch
+            MatcherResult::NoMatch
         }
     }
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
+            MatcherResult::Match => {
                 format!("is within {:?} of {:?}", self.max_abs_error, self.expected)
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!("isn't within {:?} of {:?}", self.max_abs_error, self.expected)
             }
         }
@@ -203,7 +203,7 @@ mod tests {
 
         let result = matcher.matches(&1.0f64);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -212,7 +212,7 @@ mod tests {
 
         let result = matcher.matches(&0.9f64);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -221,7 +221,7 @@ mod tests {
 
         let result = matcher.matches(&1.25f64);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -230,7 +230,7 @@ mod tests {
 
         let result = matcher.matches(&0.899999f64);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -239,7 +239,7 @@ mod tests {
 
         let result = matcher.matches(&1.100001f64);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -248,7 +248,7 @@ mod tests {
 
         let result = matcher.matches(&f64::NAN);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -282,7 +282,7 @@ mod tests {
 
         let result = matcher.matches(&f64::INFINITY);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -291,7 +291,7 @@ mod tests {
 
         let result = matcher.matches(&f64::MIN);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -300,7 +300,7 @@ mod tests {
 
         let result = matcher.matches(&f64::MAX);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[::core::prelude::v1::test]

--- a/googletest/src/matchers/none_matcher.rs
+++ b/googletest/src/matchers/none_matcher.rs
@@ -48,8 +48,8 @@ impl<T: Debug> Matcher for NoneMatcher<T> {
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => "is none".to_string(),
-            MatcherResult::DoesNotMatch => "is some(_)".to_string(),
+            MatcherResult::Match => "is none".to_string(),
+            MatcherResult::NoMatch => "is some(_)".to_string(),
         }
     }
 }
@@ -66,7 +66,7 @@ mod tests {
 
         let result = matcher.matches(&None);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -75,6 +75,6 @@ mod tests {
 
         let result = matcher.matches(&Some(0));
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 }

--- a/googletest/src/matchers/not_matcher.rs
+++ b/googletest/src/matchers/not_matcher.rs
@@ -46,8 +46,8 @@ impl<T: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher for NotMatcher<T, In
 
     fn matches(&self, actual: &T) -> MatcherResult {
         match self.inner.matches(actual) {
-            MatcherResult::Matches => MatcherResult::DoesNotMatch,
-            MatcherResult::DoesNotMatch => MatcherResult::Matches,
+            MatcherResult::Match => MatcherResult::NoMatch,
+            MatcherResult::NoMatch => MatcherResult::Match,
         }
     }
 
@@ -57,9 +57,9 @@ impl<T: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher for NotMatcher<T, In
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         self.inner.describe(if matcher_result.into() {
-            MatcherResult::DoesNotMatch
+            MatcherResult::NoMatch
         } else {
-            MatcherResult::Matches
+            MatcherResult::Match
         })
     }
 }
@@ -77,7 +77,7 @@ mod tests {
 
         let result = matcher.matches(&0);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -86,7 +86,7 @@ mod tests {
 
         let result = matcher.matches(&1);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]

--- a/googletest/src/matchers/ok_matcher.rs
+++ b/googletest/src/matchers/ok_matcher.rs
@@ -53,7 +53,7 @@ impl<T: Debug, E: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher
     type ActualT = std::result::Result<T, E>;
 
     fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
-        actual.as_ref().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::DoesNotMatch)
+        actual.as_ref().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::NoMatch)
     }
 
     fn explain_match(&self, actual: &Self::ActualT) -> String {
@@ -65,16 +65,16 @@ impl<T: Debug, E: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
+            MatcherResult::Match => {
                 format!(
                     "is a success containing a value, which {}",
-                    self.inner.describe(MatcherResult::Matches)
+                    self.inner.describe(MatcherResult::Match)
                 )
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!(
                     "is an error or a success containing a value, which {}",
-                    self.inner.describe(MatcherResult::DoesNotMatch)
+                    self.inner.describe(MatcherResult::NoMatch)
                 )
             }
         }
@@ -95,7 +95,7 @@ mod tests {
 
         let result = matcher.matches(&value);
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -105,7 +105,7 @@ mod tests {
 
         let result = matcher.matches(&value);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -115,7 +115,7 @@ mod tests {
 
         let result = matcher.matches(&value);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
             phantom_e: Default::default(),
         };
         verify_that!(
-            matcher.describe(MatcherResult::Matches),
+            matcher.describe(MatcherResult::Match),
             eq("is a success containing a value, which is equal to 1")
         )
     }

--- a/googletest/src/matchers/pointwise_matcher.rs
+++ b/googletest/src/matchers/pointwise_matcher.rs
@@ -180,13 +180,13 @@ pub mod internal {
             let mut zipped_iterator = zip(actual.into_iter(), self.matchers.iter());
             for (element, matcher) in zipped_iterator.by_ref() {
                 if !matcher.matches(element).into_bool() {
-                    return MatcherResult::DoesNotMatch;
+                    return MatcherResult::NoMatch;
                 }
             }
             if zipped_iterator.has_size_mismatch() {
-                MatcherResult::DoesNotMatch
+                MatcherResult::NoMatch
             } else {
-                MatcherResult::Matches
+                MatcherResult::Match
             }
         }
 
@@ -226,7 +226,7 @@ pub mod internal {
                 if matcher_result.into() { "has" } else { "doesn't have" },
                 self.matchers
                     .iter()
-                    .map(|m| m.describe(MatcherResult::Matches))
+                    .map(|m| m.describe(MatcherResult::Match))
                     .collect::<Description>()
                     .enumerate()
                     .indent()

--- a/googletest/src/matchers/predicate_matcher.rs
+++ b/googletest/src/matchers/predicate_matcher.rs
@@ -133,8 +133,8 @@ where
 
     fn describe(&self, result: MatcherResult) -> String {
         match result {
-            MatcherResult::Matches => "matches".to_string(),
-            MatcherResult::DoesNotMatch => "does not match".to_string(),
+            MatcherResult::Match => "matches".to_string(),
+            MatcherResult::NoMatch => "does not match".to_string(),
         }
     }
 }
@@ -152,8 +152,8 @@ where
 
     fn describe(&self, result: MatcherResult) -> String {
         match result {
-            MatcherResult::Matches => self.positive_description.to_description(),
-            MatcherResult::DoesNotMatch => self.negative_description.to_description(),
+            MatcherResult::Match => self.positive_description.to_description(),
+            MatcherResult::NoMatch => self.negative_description.to_description(),
         }
     }
 }

--- a/googletest/src/matchers/some_matcher.rs
+++ b/googletest/src/matchers/some_matcher.rs
@@ -48,7 +48,7 @@ impl<T: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher for SomeMatcher<T, I
     type ActualT = Option<T>;
 
     fn matches(&self, actual: &Option<T>) -> MatcherResult {
-        actual.as_ref().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::DoesNotMatch)
+        actual.as_ref().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::NoMatch)
     }
 
     fn explain_match(&self, actual: &Option<T>) -> String {
@@ -60,13 +60,13 @@ impl<T: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher for SomeMatcher<T, I
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => {
-                format!("has a value which {}", self.inner.describe(MatcherResult::Matches))
+            MatcherResult::Match => {
+                format!("has a value which {}", self.inner.describe(MatcherResult::Match))
             }
-            MatcherResult::DoesNotMatch => {
+            MatcherResult::NoMatch => {
                 format!(
                     "is None or has a value which {}",
-                    self.inner.describe(MatcherResult::DoesNotMatch)
+                    self.inner.describe(MatcherResult::NoMatch)
                 )
             }
         }
@@ -86,7 +86,7 @@ mod tests {
 
         let result = matcher.matches(&Some(1));
 
-        verify_that!(result, eq(MatcherResult::Matches))
+        verify_that!(result, eq(MatcherResult::Match))
     }
 
     #[test]
@@ -95,7 +95,7 @@ mod tests {
 
         let result = matcher.matches(&Some(0));
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -104,7 +104,7 @@ mod tests {
 
         let result = matcher.matches(&None);
 
-        verify_that!(result, eq(MatcherResult::DoesNotMatch))
+        verify_that!(result, eq(MatcherResult::NoMatch))
     }
 
     #[test]
@@ -126,7 +126,7 @@ mod tests {
     #[test]
     fn some_describe_matches() -> Result<()> {
         verify_that!(
-            some(eq(1)).describe(MatcherResult::Matches),
+            some(eq(1)).describe(MatcherResult::Match),
             eq("has a value which is equal to 1")
         )
     }
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn some_describe_does_not_match() -> Result<()> {
         verify_that!(
-            some(eq(1)).describe(MatcherResult::DoesNotMatch),
+            some(eq(1)).describe(MatcherResult::NoMatch),
             eq("is None or has a value which isn't equal to 1")
         )
     }

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -460,7 +460,7 @@ impl Configuration {
             // Split returns an iterator over the "boundaries" left and right of the
             // substring to be matched, of which there is one more than the number of
             // substrings.
-            matches!(times.matches(&(actual.split(expected).count() - 1)), MatcherResult::Matches)
+            matches!(times.matches(&(actual.split(expected).count() - 1)), MatcherResult::Match)
         } else {
             actual.contains(expected)
         }
@@ -486,20 +486,20 @@ impl Configuration {
             if !addenda.is_empty() { format!(" ({})", addenda.join(", ")) } else { "".into() };
         let match_mode_description = match self.mode {
             MatchMode::Equals => match matcher_result {
-                MatcherResult::Matches => "is equal to",
-                MatcherResult::DoesNotMatch => "isn't equal to",
+                MatcherResult::Match => "is equal to",
+                MatcherResult::NoMatch => "isn't equal to",
             },
             MatchMode::Contains => match matcher_result {
-                MatcherResult::Matches => "contains a substring",
-                MatcherResult::DoesNotMatch => "does not contain a substring",
+                MatcherResult::Match => "contains a substring",
+                MatcherResult::NoMatch => "does not contain a substring",
             },
             MatchMode::StartsWith => match matcher_result {
-                MatcherResult::Matches => "starts with prefix",
-                MatcherResult::DoesNotMatch => "does not start with",
+                MatcherResult::Match => "starts with prefix",
+                MatcherResult::NoMatch => "does not start with",
             },
             MatchMode::EndsWith => match matcher_result {
-                MatcherResult::Matches => "ends with suffix",
-                MatcherResult::DoesNotMatch => "does not end with",
+                MatcherResult::Match => "ends with suffix",
+                MatcherResult::NoMatch => "does not end with",
             },
         };
         format!("{match_mode_description} {expected:?}{extra}")
@@ -726,8 +726,8 @@ mod tests {
     }
 
     #[test]
-    fn matches_string_containing_expected_value_in_contains_mode_while_ignoring_ascii_case()
-    -> Result<()> {
+    fn matches_string_containing_expected_value_in_contains_mode_while_ignoring_ascii_case(
+    ) -> Result<()> {
         verify_that!("Some string", contains_substring("STR").ignoring_ascii_case())
     }
 
@@ -810,7 +810,7 @@ mod tests {
     fn describes_itself_for_matching_result() -> Result<()> {
         let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("is equal to \"A string\"")
         )
     }
@@ -819,7 +819,7 @@ mod tests {
     fn describes_itself_for_non_matching_result() -> Result<()> {
         let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::DoesNotMatch),
+            Matcher::describe(&matcher, MatcherResult::NoMatch),
             eq("isn't equal to \"A string\"")
         )
     }
@@ -829,7 +829,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> =
             StrMatcher::with_default_config("A string").ignoring_leading_whitespace();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("is equal to \"A string\" (ignoring leading whitespace)")
         )
     }
@@ -839,7 +839,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> =
             StrMatcher::with_default_config("A string").ignoring_leading_whitespace();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::DoesNotMatch),
+            Matcher::describe(&matcher, MatcherResult::NoMatch),
             eq("isn't equal to \"A string\" (ignoring leading whitespace)")
         )
     }
@@ -849,7 +849,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> =
             StrMatcher::with_default_config("A string").ignoring_trailing_whitespace();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("is equal to \"A string\" (ignoring trailing whitespace)")
         )
     }
@@ -860,7 +860,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> =
             StrMatcher::with_default_config("A string").ignoring_outer_whitespace();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("is equal to \"A string\" (ignoring leading and trailing whitespace)")
         )
     }
@@ -870,19 +870,19 @@ mod tests {
         let matcher: StrMatcher<&str, _> =
             StrMatcher::with_default_config("A string").ignoring_ascii_case();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("is equal to \"A string\" (ignoring ASCII case)")
         )
     }
 
     #[test]
-    fn describes_itself_for_matching_result_ignoring_ascii_case_and_leading_whitespace()
-    -> Result<()> {
+    fn describes_itself_for_matching_result_ignoring_ascii_case_and_leading_whitespace(
+    ) -> Result<()> {
         let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string")
             .ignoring_leading_whitespace()
             .ignoring_ascii_case();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("is equal to \"A string\" (ignoring leading whitespace, ignoring ASCII case)")
         )
     }
@@ -891,7 +891,7 @@ mod tests {
     fn describes_itself_for_matching_result_in_contains_mode() -> Result<()> {
         let matcher: StrMatcher<&str, _> = contains_substring("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("contains a substring \"A string\"")
         )
     }
@@ -900,7 +900,7 @@ mod tests {
     fn describes_itself_for_non_matching_result_in_contains_mode() -> Result<()> {
         let matcher: StrMatcher<&str, _> = contains_substring("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::DoesNotMatch),
+            Matcher::describe(&matcher, MatcherResult::NoMatch),
             eq("does not contain a substring \"A string\"")
         )
     }
@@ -909,7 +909,7 @@ mod tests {
     fn describes_itself_with_count_number() -> Result<()> {
         let matcher: StrMatcher<&str, _> = contains_substring("A string").times(gt(2));
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("contains a substring \"A string\" (count is greater than 2)")
         )
     }
@@ -918,7 +918,7 @@ mod tests {
     fn describes_itself_for_matching_result_in_starts_with_mode() -> Result<()> {
         let matcher: StrMatcher<&str, _> = starts_with("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("starts with prefix \"A string\"")
         )
     }
@@ -927,7 +927,7 @@ mod tests {
     fn describes_itself_for_non_matching_result_in_starts_with_mode() -> Result<()> {
         let matcher: StrMatcher<&str, _> = starts_with("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::DoesNotMatch),
+            Matcher::describe(&matcher, MatcherResult::NoMatch),
             eq("does not start with \"A string\"")
         )
     }
@@ -936,7 +936,7 @@ mod tests {
     fn describes_itself_for_matching_result_in_ends_with_mode() -> Result<()> {
         let matcher: StrMatcher<&str, _> = ends_with("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq("ends with suffix \"A string\"")
         )
     }
@@ -945,7 +945,7 @@ mod tests {
     fn describes_itself_for_non_matching_result_in_ends_with_mode() -> Result<()> {
         let matcher: StrMatcher<&str, _> = ends_with("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::DoesNotMatch),
+            Matcher::describe(&matcher, MatcherResult::NoMatch),
             eq("does not end with \"A string\"")
         )
     }
@@ -1017,8 +1017,8 @@ mod tests {
     }
 
     #[test]
-    fn match_explanation_for_starts_with_includes_both_versions_of_differing_last_line()
-    -> Result<()> {
+    fn match_explanation_for_starts_with_includes_both_versions_of_differing_last_line(
+    ) -> Result<()> {
         let result = verify_that!(
             indoc!(
                 "
@@ -1121,8 +1121,8 @@ mod tests {
     }
 
     #[test]
-    fn match_explanation_for_contains_substring_shows_diff_when_first_and_last_line_are_incomplete()
-    -> Result<()> {
+    fn match_explanation_for_contains_substring_shows_diff_when_first_and_last_line_are_incomplete(
+    ) -> Result<()> {
         let result = verify_that!(
             indoc!(
                 "

--- a/googletest/src/matchers/subset_of_matcher.rs
+++ b/googletest/src/matchers/subset_of_matcher.rs
@@ -103,10 +103,10 @@ where
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         for actual_item in actual {
             if self.expected_is_missing(actual_item) {
-                return MatcherResult::DoesNotMatch;
+                return MatcherResult::NoMatch;
             }
         }
-        MatcherResult::Matches
+        MatcherResult::Match
     }
 
     fn explain_match(&self, actual: &ActualT) -> String {
@@ -126,8 +126,8 @@ where
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is a subset of {:#?}", self.superset),
-            MatcherResult::DoesNotMatch => format!("isn't a subset of {:#?}", self.superset),
+            MatcherResult::Match => format!("is a subset of {:#?}", self.superset),
+            MatcherResult::NoMatch => format!("isn't a subset of {:#?}", self.superset),
         }
     }
 }

--- a/googletest/src/matchers/superset_of_matcher.rs
+++ b/googletest/src/matchers/superset_of_matcher.rs
@@ -103,10 +103,10 @@ where
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         for expected_item in &self.subset {
             if actual_is_missing(actual, expected_item) {
-                return MatcherResult::DoesNotMatch;
+                return MatcherResult::NoMatch;
             }
         }
-        MatcherResult::Matches
+        MatcherResult::Match
     }
 
     fn explain_match(&self, actual: &ActualT) -> String {
@@ -125,8 +125,8 @@ where
 
     fn describe(&self, matcher_result: MatcherResult) -> String {
         match matcher_result {
-            MatcherResult::Matches => format!("is a superset of {:#?}", self.subset),
-            MatcherResult::DoesNotMatch => format!("isn't a superset of {:#?}", self.subset),
+            MatcherResult::Match => format!("is a superset of {:#?}", self.subset),
+            MatcherResult::NoMatch => format!("isn't a superset of {:#?}", self.subset),
         }
     }
 }

--- a/googletest/src/matchers/tuple_matcher.rs
+++ b/googletest/src/matchers/tuple_matcher.rs
@@ -352,19 +352,19 @@ pub mod internal {
 
                 fn matches(&self, actual: &($($field_type,)*)) -> MatcherResult {
                     $(match self.$field_number.matches(&actual.$field_number) {
-                        MatcherResult::Matches => {},
-                        MatcherResult::DoesNotMatch => {
-                            return MatcherResult::DoesNotMatch;
+                        MatcherResult::Match => {},
+                        MatcherResult::NoMatch => {
+                            return MatcherResult::NoMatch;
                         }
                     })*
-                    MatcherResult::Matches
+                    MatcherResult::Match
                 }
 
                 fn explain_match(&self, actual: &($($field_type,)*)) -> String {
                     let mut explanation = format!("which {}", self.describe(self.matches(actual)));
                     $(match self.$field_number.matches(&actual.$field_number) {
-                        MatcherResult::Matches => {},
-                        MatcherResult::DoesNotMatch => {
+                        MatcherResult::Match => {},
+                        MatcherResult::NoMatch => {
                             writeln!(
                                 &mut explanation,
                                 concat!("Element #", $field_number, " is {:?}, {}"),
@@ -378,7 +378,7 @@ pub mod internal {
 
                 fn describe(&self, matcher_result: MatcherResult) -> String {
                     match matcher_result {
-                        MatcherResult::Matches => {
+                        MatcherResult::Match => {
                             format!(
                                 concat!(
                                     "is a tuple whose values respectively match:\n",
@@ -387,13 +387,13 @@ pub mod internal {
                                 $(self.$field_number.describe(matcher_result)),*
                             )
                         }
-                        MatcherResult::DoesNotMatch => {
+                        MatcherResult::NoMatch => {
                             format!(
                                 concat!(
                                     "is a tuple whose values do not respectively match:\n",
                                     $(replace_expr!($field_number, "  {},\n")),*
                                 ),
-                                $(self.$field_number.describe(MatcherResult::Matches)),*
+                                $(self.$field_number.describe(MatcherResult::Match)),*
                             )
                         }
                     }

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -432,7 +432,7 @@ pub mod internal {
                 if matcher_result.into() { "contains" } else { "doesn't contain" },
                 self.elements
                     .iter()
-                    .map(|matcher| matcher.describe(MatcherResult::Matches))
+                    .map(|matcher| matcher.describe(MatcherResult::Match))
                     .collect::<Description>()
                     .enumerate()
                     .indent()
@@ -511,8 +511,8 @@ pub mod internal {
                     .iter()
                     .map(|(key_matcher, value_matcher)| format!(
                         "{} => {}",
-                        key_matcher.describe(MatcherResult::Matches),
-                        value_matcher.describe(MatcherResult::Matches)
+                        key_matcher.describe(MatcherResult::Match),
+                        value_matcher.describe(MatcherResult::Match)
                     ))
                     .collect::<Description>()
                     .indent()
@@ -597,8 +597,7 @@ pub mod internal {
         where
             for<'b> &'b ContainerT: IntoIterator<Item = &'b T>,
         {
-            let mut matrix =
-                MatchMatrix(vec![[MatcherResult::DoesNotMatch; N]; count_elements(actual)]);
+            let mut matrix = MatchMatrix(vec![[MatcherResult::NoMatch; N]; count_elements(actual)]);
             for (actual_idx, actual) in actual.into_iter().enumerate() {
                 for (expected_idx, expected) in expected.iter().enumerate() {
                     matrix.0[actual_idx][expected_idx] = expected.matches(actual);
@@ -614,8 +613,7 @@ pub mod internal {
         where
             for<'b> &'b ContainerT: IntoIterator<Item = (&'b KeyT, &'b ValueT)>,
         {
-            let mut matrix =
-                MatchMatrix(vec![[MatcherResult::DoesNotMatch; N]; count_elements(actual)]);
+            let mut matrix = MatchMatrix(vec![[MatcherResult::NoMatch; N]; count_elements(actual)]);
             for (actual_idx, (actual_key, actual_value)) in actual.into_iter().enumerate() {
                 for (expected_idx, (expected_key, expected_value)) in expected.iter().enumerate() {
                     matrix.0[actual_idx][expected_idx] = (expected_key.matches(actual_key).into()
@@ -972,7 +970,7 @@ pub mod internal {
                 format!(
                     "Actual element {:?} at index {actual_idx} matched expected element `{}` at index {expected_idx}.",
                     actual[actual_idx],
-                    expected[expected_idx].describe(MatcherResult::Matches),
+                    expected[expected_idx].describe(MatcherResult::Match),
             )});
 
             let unmatched_actual = self.get_unmatched_actual().map(|actual_idx| {
@@ -984,7 +982,7 @@ pub mod internal {
 
             let unmatched_expected = self.get_unmatched_expected().into_iter().map(|expected_idx|{format!(
                 "Expected element `{}` at index {expected_idx} did not match any remaining actual element.",
-                expected[expected_idx].describe(MatcherResult::Matches)
+                expected[expected_idx].describe(MatcherResult::Match)
             )});
 
             let best_match = matches
@@ -1021,8 +1019,8 @@ pub mod internal {
                         "Actual element {:?} => {:?} at index {actual_idx} matched expected element `{}` => `{}` at index {expected_idx}.",
                         actual[actual_idx].0,
                         actual[actual_idx].1,
-                        expected[expected_idx].0.describe(MatcherResult::Matches),
-                        expected[expected_idx].1.describe(MatcherResult::Matches),
+                        expected[expected_idx].0.describe(MatcherResult::Match),
+                        expected[expected_idx].1.describe(MatcherResult::Match),
                     )
                 });
 
@@ -1040,8 +1038,8 @@ pub mod internal {
                 .map(|expected_idx| {
                     format!(
                         "Expected element `{}` => `{}` at index {expected_idx} did not match any remaining actual element.",
-                        expected[expected_idx].0.describe(MatcherResult::Matches),
-                        expected[expected_idx].1.describe(MatcherResult::Matches),
+                        expected[expected_idx].0.describe(MatcherResult::Match),
+                        expected[expected_idx].1.describe(MatcherResult::Match),
                     )
                 });
 
@@ -1074,12 +1072,12 @@ mod tests {
         // aren't dropped too early.
         let matchers = ((eq(2), eq("Two")), (eq(1), eq("One")), (eq(3), eq("Three")));
         let matcher: UnorderedElementsOfMapAreMatcher<HashMap<i32, &str>, _, _, 3> = unordered_elements_are![
-            (matchers.0.0, matchers.0.1),
-            (matchers.1.0, matchers.1.1),
-            (matchers.2.0, matchers.2.1)
+            (matchers.0 .0, matchers.0 .1),
+            (matchers.1 .0, matchers.1 .1),
+            (matchers.2 .0, matchers.2 .1)
         ];
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Matches),
+            Matcher::describe(&matcher, MatcherResult::Match),
             eq(indoc!(
                 "
                 contains elements matching in any order:
@@ -1099,9 +1097,9 @@ mod tests {
         // aren't dropped too early.
         let matchers = ((anything(), eq(1)), (anything(), eq(2)), (anything(), eq(2)));
         let matcher: UnorderedElementsOfMapAreMatcher<HashMap<u32, u32>, _, _, 3> = unordered_elements_are![
-            (matchers.0.0, matchers.0.1),
-            (matchers.1.0, matchers.1.1),
-            (matchers.2.0, matchers.2.1),
+            (matchers.0 .0, matchers.0 .1),
+            (matchers.1 .0, matchers.1 .1),
+            (matchers.2 .0, matchers.2 .1),
         ];
         let value: HashMap<u32, u32> = HashMap::from_iter([(0, 1), (1, 1), (2, 2)]);
         verify_that!(

--- a/googletest/tests/field_matcher_test.rs
+++ b/googletest/tests/field_matcher_test.rs
@@ -40,7 +40,7 @@ fn field_error_message_shows_field_name_and_inner_matcher() -> Result<()> {
     let matcher = field!(IntField.int, eq(31));
 
     verify_that!(
-        matcher.describe(MatcherResult::Matches),
+        matcher.describe(MatcherResult::Match),
         eq("has field `int`, which is equal to 31")
     )
 }

--- a/googletest/tests/property_matcher_test.rs
+++ b/googletest/tests/property_matcher_test.rs
@@ -121,7 +121,7 @@ fn does_not_match_struct_with_non_matching_property() -> Result<()> {
 #[test]
 fn describes_itself_in_matching_case() -> Result<()> {
     verify_that!(
-        property!(SomeStruct.get_property(), eq(1)).describe(MatcherResult::Matches),
+        property!(SomeStruct.get_property(), eq(1)).describe(MatcherResult::Match),
         eq("has property `get_property()`, which is equal to 1")
     )
 }
@@ -129,7 +129,7 @@ fn describes_itself_in_matching_case() -> Result<()> {
 #[test]
 fn describes_itself_in_not_matching_case() -> Result<()> {
     verify_that!(
-        property!(SomeStruct.get_property(), eq(1)).describe(MatcherResult::DoesNotMatch),
+        property!(SomeStruct.get_property(), eq(1)).describe(MatcherResult::NoMatch),
         eq("has property `get_property()`, which isn't equal to 1")
     )
 }
@@ -155,7 +155,7 @@ fn explains_mismatch_referencing_explanation_of_inner_matcher() -> Result<()> {
 #[test]
 fn describes_itself_in_matching_case_for_ref() -> Result<()> {
     verify_that!(
-        property!(ref SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::Matches),
+        property!(ref SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::Match),
         eq("has property `get_property_ref()`, which is equal to 1")
     )
 }
@@ -163,7 +163,7 @@ fn describes_itself_in_matching_case_for_ref() -> Result<()> {
 #[test]
 fn describes_itself_in_not_matching_case_for_ref() -> Result<()> {
     verify_that!(
-        property!(ref SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::DoesNotMatch),
+        property!(ref SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::NoMatch),
         eq("has property `get_property_ref()`, which isn't equal to 1")
     )
 }

--- a/googletest/tests/tuple_matcher_test.rs
+++ b/googletest/tests/tuple_matcher_test.rs
@@ -210,7 +210,7 @@ fn tuple_matcher_with_trailing_comma_matches_matching_12_tuple() -> Result<()> {
 #[test]
 fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
     verify_that!(
-        tuple!(eq(1)).describe(MatcherResult::Matches),
+        tuple!(eq(1)).describe(MatcherResult::Match),
         eq(indoc!(
             "
             is a tuple whose values respectively match:
@@ -223,7 +223,7 @@ fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
 #[test]
 fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
-        tuple!(eq(1)).describe(MatcherResult::DoesNotMatch),
+        tuple!(eq(1)).describe(MatcherResult::NoMatch),
         eq(indoc!(
             "
             is a tuple whose values do not respectively match:
@@ -236,7 +236,7 @@ fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
 #[test]
 fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
     verify_that!(
-        tuple!(eq(1), eq(2)).describe(MatcherResult::Matches),
+        tuple!(eq(1), eq(2)).describe(MatcherResult::Match),
         eq(indoc!(
             "
             is a tuple whose values respectively match:
@@ -250,7 +250,7 @@ fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
 #[test]
 fn tuple_matcher_2_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
-        tuple!(eq(1), eq(2)).describe(MatcherResult::DoesNotMatch),
+        tuple!(eq(1), eq(2)).describe(MatcherResult::NoMatch),
         eq(indoc!(
             "
             is a tuple whose values do not respectively match:


### PR DESCRIPTION
These new names are more concise and better correspond to the naming of `MatcherResult`. Namely, they are nouns specifying the result rather than verbs.