### PR TITLE
Replace the `tuple!` macro with an implementation of `Matcher` for tuples

### DIFF
--- a/googletest/crate_docs.md
+++ b/googletest/crate_docs.md
@@ -118,7 +118,6 @@ The following matchers are provided in GoogleTest Rust:
 | [`starts_with`]      | A string starting with the given prefix.                                 |
 | [`subset_of`]        | A container all of whose elements are contained in the argument.         |
 | [`superset_of`]      | A container containing all elements of the argument.                     |
-| [`tuple!`]           | A tuple whose elements the arguments match.                              |
 | [`unordered_elements_are!`] | A container whose elements the arguments match, in any order.     |
 
 [`anything`]: matchers::anything

--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -58,6 +58,61 @@
 ///     `verify_that!(actual, elements_are![m1, m2, ...])`
 ///   * `verify_that!(actual, {m1, m2, ...})` is equivalent to
 ///     `verify_that!(actual, unordered_elements_are![m1, m2, ...])`
+///
+/// ## Matching against tuples
+///
+/// One can match against a tuple by constructing a tuple of matchers as follows:
+///
+/// ```
+/// # use googletest::prelude::*;
+/// # fn should_pass() -> Result<()> {
+/// verify_that!((123, 456), (eq(123), eq(456)))?; // Passes
+/// #     Ok(())
+/// # }
+/// # fn should_fail() -> Result<()> {
+/// verify_that!((123, 456), (eq(123), eq(0)))?; // Fails: second matcher does not match
+/// #     Ok(())
+/// # }
+/// # should_pass().unwrap();
+/// # should_fail().unwrap_err();
+/// ```
+///
+/// This also works with composed matchers:
+///
+/// ```
+/// # use googletest::prelude::*;
+/// # fn should_pass() -> Result<()> {
+/// verify_that!((123, 456), not((eq(456), eq(123))))?; // Passes
+/// #     Ok(())
+/// # }
+/// # should_pass().unwrap();
+/// ```
+///
+/// Matchers must correspond to the actual tuple in count and type. Otherwise
+/// the test will fail to compile.
+///
+/// ```compile_fail
+/// # use googletest::prelude::*;
+/// # fn should_not_compile() -> Result<()> {
+/// verify_that!((123, 456), (eq(123),))?; // Does not compile: wrong tuple size
+/// verify_that!((123, "A string"), (eq(123), eq(456)))?; // Does not compile: wrong type
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// All fields must be covered by matchers. Use
+/// [`anything`][crate::matchers::anything] for fields which are not relevant
+/// for the test.
+///
+/// ```
+/// # use googletest::prelude::*;
+/// verify_that!((123, 456), (eq(123), anything()))
+/// #     .unwrap();
+/// ```
+///
+/// This supports tuples of up to 12 elements. Tuples longer than that do not
+/// automatically inherit the `Debug` trait from their members, so are generally
+/// not supported; see [Rust by Example](https://doc.rust-lang.org/rust-by-example/primitives/tuples.html#tuples).
 #[macro_export]
 macro_rules! verify_that {
     ($actual:expr, [$($expecteds:expr),+]) => {

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -51,7 +51,7 @@ pub mod prelude {
     // Matcher macros
     pub use super::{
         all, contains_each, elements_are, field, is_contained_in, matches_pattern, pat, pointwise,
-        property, tuple, unordered_elements_are,
+        property, unordered_elements_are,
     };
 }
 

--- a/googletest/src/matchers/tuple_matcher.rs
+++ b/googletest/src/matchers/tuple_matcher.rs
@@ -16,308 +16,13 @@
 // macro is documented at the top level.
 #![doc(hidden)]
 
-/// Matches a tuple whose elements are matched by each of the given matchers.
-///
-/// This takes as arguments sequence of [`Matcher`][crate::matcher::Matcher]
-/// corresponding to the tuple against which it matches. Each matcher is
-/// applied to the corresponding tuple element.
-///
-/// ```
-/// # use googletest::prelude::*;
-/// # fn should_pass() -> Result<()> {
-/// verify_that!((123, 456), tuple!(eq(123), eq(456)))?; // Passes
-/// #     Ok(())
-/// # }
-/// # fn should_fail() -> Result<()> {
-/// verify_that!((123, 456), tuple!(eq(123), eq(0)))?; // Fails: second matcher does not match
-/// #     Ok(())
-/// # }
-/// # should_pass().unwrap();
-/// # should_fail().unwrap_err();
-/// ```
-///
-/// Matchers must correspond to the actual tuple in count and type. Otherwise
-/// the test will fail to compile.
-///
-/// ```compile_fail
-/// # use googletest::prelude::*;
-/// # fn should_not_compile() -> Result<()> {
-/// verify_that!((123, 456), tuple!(eq(123)))?; // Does not compile: wrong tuple size
-/// verify_that!((123, "A string"), tuple!(eq(123), eq(456)))?; // Does not compile: wrong type
-/// #     Ok(())
-/// # }
-/// ```
-///
-/// All fields must be covered by matchers. Use
-/// [`anything`][crate::matchers::anything] for fields which are not relevant
-/// for the test.
-///
-/// ```
-/// # use googletest::prelude::*;
-/// verify_that!((123, 456), tuple!(eq(123), anything()))
-/// #     .unwrap();
-/// ```
-///
-/// This supports tuples of up to 12 elements. Tuples longer than that do not
-/// automatically inherit the `Debug` trait from their members, so are generally
-/// not supported; see [Rust by Example](https://doc.rust-lang.org/rust-by-example/primitives/tuples.html#tuples).
-///
-/// This macro is the analogue of [`matches_pattern`][crate::matches_pattern]
-/// for tuples. To match on fields of tuple structs, structs, and enums, use
-/// [`matches_pattern`][crate::matches_pattern].
-#[macro_export]
-macro_rules! tuple {
-    ($($t:tt)*) => { $crate::tuple_internal!($($t)*) }
-}
-
-// Internal-only macro created so that the macro definition does not appear in
-// generated documentation.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! tuple_internal {
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr,
-        $matcher4:expr,
-        $matcher5:expr,
-        $matcher6:expr,
-        $matcher7:expr,
-        $matcher8:expr,
-        $matcher9:expr,
-        $matcher10:expr,
-        $matcher11:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher12;
-        TupleMatcher12(
-            $matcher0,
-            $matcher1,
-            $matcher2,
-            $matcher3,
-            $matcher4,
-            $matcher5,
-            $matcher6,
-            $matcher7,
-            $matcher8,
-            $matcher9,
-            $matcher10,
-            $matcher11,
-            Default::default(),
-        )
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr,
-        $matcher4:expr,
-        $matcher5:expr,
-        $matcher6:expr,
-        $matcher7:expr,
-        $matcher8:expr,
-        $matcher9:expr,
-        $matcher10:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher11;
-        TupleMatcher11(
-            $matcher0,
-            $matcher1,
-            $matcher2,
-            $matcher3,
-            $matcher4,
-            $matcher5,
-            $matcher6,
-            $matcher7,
-            $matcher8,
-            $matcher9,
-            $matcher10,
-            Default::default(),
-        )
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr,
-        $matcher4:expr,
-        $matcher5:expr,
-        $matcher6:expr,
-        $matcher7:expr,
-        $matcher8:expr,
-        $matcher9:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher10;
-        TupleMatcher10(
-            $matcher0,
-            $matcher1,
-            $matcher2,
-            $matcher3,
-            $matcher4,
-            $matcher5,
-            $matcher6,
-            $matcher7,
-            $matcher8,
-            $matcher9,
-            Default::default(),
-        )
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr,
-        $matcher4:expr,
-        $matcher5:expr,
-        $matcher6:expr,
-        $matcher7:expr,
-        $matcher8:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher9;
-        TupleMatcher9(
-            $matcher0,
-            $matcher1,
-            $matcher2,
-            $matcher3,
-            $matcher4,
-            $matcher5,
-            $matcher6,
-            $matcher7,
-            $matcher8,
-            Default::default(),
-        )
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr,
-        $matcher4:expr,
-        $matcher5:expr,
-        $matcher6:expr,
-        $matcher7:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher8;
-        TupleMatcher8(
-            $matcher0,
-            $matcher1,
-            $matcher2,
-            $matcher3,
-            $matcher4,
-            $matcher5,
-            $matcher6,
-            $matcher7,
-            Default::default(),
-        )
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr,
-        $matcher4:expr,
-        $matcher5:expr,
-        $matcher6:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher7;
-        TupleMatcher7(
-            $matcher0,
-            $matcher1,
-            $matcher2,
-            $matcher3,
-            $matcher4,
-            $matcher5,
-            $matcher6,
-            Default::default(),
-        )
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr,
-        $matcher4:expr,
-        $matcher5:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher6;
-        TupleMatcher6(
-            $matcher0,
-            $matcher1,
-            $matcher2,
-            $matcher3,
-            $matcher4,
-            $matcher5,
-            Default::default(),
-        )
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr,
-        $matcher4:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher5;
-        TupleMatcher5($matcher0, $matcher1, $matcher2, $matcher3, $matcher4, Default::default())
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr,
-        $matcher3:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher4;
-        TupleMatcher4($matcher0, $matcher1, $matcher2, $matcher3, Default::default())
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr,
-        $matcher2:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher3;
-        TupleMatcher3($matcher0, $matcher1, $matcher2, Default::default())
-    }};
-
-    (
-        $matcher0:expr,
-        $matcher1:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher2;
-        TupleMatcher2($matcher0, $matcher1, Default::default())
-    }};
-
-    (
-        $matcher0:expr $(,)?
-    ) => {{
-        use $crate::matchers::tuple_matcher::internal::TupleMatcher1;
-        TupleMatcher1($matcher0, Default::default())
-    }};
-
-    () => {{
-        use $crate::matchers::eq;
-        eq(())
-    }};
-}
-
 /// Functions for use only by the declarative macros in this module.
 ///
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
 pub mod internal {
     use crate::matcher::{Matcher, MatcherResult};
-    use std::{
-        fmt::{Debug, Write},
-        marker::PhantomData,
-    };
+    use std::fmt::{Debug, Write};
 
     /// Replaces the first expression with the second at compile time.
     ///
@@ -333,20 +38,31 @@ pub mod internal {
         };
     }
 
+    // This implementation is provided for completeness, but is completely trivial.
+    // The only actual value which can be supplied is (), which must match.
+    impl Matcher for () {
+        type ActualT = ();
+
+        fn matches(&self, _: &Self::ActualT) -> MatcherResult {
+            MatcherResult::Matches
+        }
+
+        fn describe(&self, matcher_result: MatcherResult) -> String {
+            match matcher_result {
+                MatcherResult::Matches => format!("is the empty tuple"),
+                MatcherResult::DoesNotMatch => format!("is not the empty tuple"),
+            }
+        }
+    }
+
     /// Generates a tuple matcher for tuples of a specific length.
     ///
     /// **For internal use only. API stablility is not guaranteed!**
     #[doc(hidden)]
     macro_rules! tuple_matcher_n {
-        ($name:ident, $([$field_number:tt, $matcher_type:ident, $field_type:ident]),*) => {
-            #[doc(hidden)]
-            pub struct $name<$($field_type, $matcher_type),*>(
-                $(pub $matcher_type),*,
-                pub PhantomData<($($field_type,)*)>,
-            );
-
+        ($([$field_number:tt, $matcher_type:ident, $field_type:ident]),*) => {
             impl<$($field_type: Debug, $matcher_type: Matcher<ActualT = $field_type>),*>
-                Matcher for $name<$($field_type, $matcher_type),*>
+                Matcher for ($($matcher_type,)*)
             {
                 type ActualT = ($($field_type,)*);
 
@@ -402,35 +118,19 @@ pub mod internal {
         };
     }
 
-    tuple_matcher_n!(TupleMatcher1, [0, I0, T0]);
+    tuple_matcher_n!([0, I0, T0]);
 
-    tuple_matcher_n!(TupleMatcher2, [0, I0, T0], [1, I1, T1]);
+    tuple_matcher_n!([0, I0, T0], [1, I1, T1]);
 
-    tuple_matcher_n!(TupleMatcher3, [0, I0, T0], [1, I1, T1], [2, I2, T2]);
+    tuple_matcher_n!([0, I0, T0], [1, I1, T1], [2, I2, T2]);
 
-    tuple_matcher_n!(TupleMatcher4, [0, I0, T0], [1, I1, T1], [2, I2, T2], [3, I3, T3]);
+    tuple_matcher_n!([0, I0, T0], [1, I1, T1], [2, I2, T2], [3, I3, T3]);
 
-    tuple_matcher_n!(
-        TupleMatcher5,
-        [0, I0, T0],
-        [1, I1, T1],
-        [2, I2, T2],
-        [3, I3, T3],
-        [4, I4, T4]
-    );
+    tuple_matcher_n!([0, I0, T0], [1, I1, T1], [2, I2, T2], [3, I3, T3], [4, I4, T4]);
+
+    tuple_matcher_n!([0, I0, T0], [1, I1, T1], [2, I2, T2], [3, I3, T3], [4, I4, T4], [5, I5, T5]);
 
     tuple_matcher_n!(
-        TupleMatcher6,
-        [0, I0, T0],
-        [1, I1, T1],
-        [2, I2, T2],
-        [3, I3, T3],
-        [4, I4, T4],
-        [5, I5, T5]
-    );
-
-    tuple_matcher_n!(
-        TupleMatcher7,
         [0, I0, T0],
         [1, I1, T1],
         [2, I2, T2],
@@ -441,7 +141,6 @@ pub mod internal {
     );
 
     tuple_matcher_n!(
-        TupleMatcher8,
         [0, I0, T0],
         [1, I1, T1],
         [2, I2, T2],
@@ -453,7 +152,6 @@ pub mod internal {
     );
 
     tuple_matcher_n!(
-        TupleMatcher9,
         [0, I0, T0],
         [1, I1, T1],
         [2, I2, T2],
@@ -466,7 +164,6 @@ pub mod internal {
     );
 
     tuple_matcher_n!(
-        TupleMatcher10,
         [0, I0, T0],
         [1, I1, T1],
         [2, I2, T2],
@@ -480,7 +177,6 @@ pub mod internal {
     );
 
     tuple_matcher_n!(
-        TupleMatcher11,
         [0, I0, T0],
         [1, I1, T1],
         [2, I2, T2],
@@ -495,7 +191,6 @@ pub mod internal {
     );
 
     tuple_matcher_n!(
-        TupleMatcher12,
         [0, I0, T0],
         [1, I1, T1],
         [2, I2, T2],

--- a/googletest/tests/composition_test.rs
+++ b/googletest/tests/composition_test.rs
@@ -67,5 +67,5 @@ fn elements_are_works_as_inner_matcher() -> Result<()> {
 
 #[test]
 fn tuple_works_as_inner_matcher() -> Result<()> {
-    verify_that!(vec![(123,)], elements_are![tuple!(eq(123))])
+    verify_that!(vec![(123,)], elements_are![(eq(123),)])
 }

--- a/googletest/tests/tuple_matcher_test.rs
+++ b/googletest/tests/tuple_matcher_test.rs
@@ -18,77 +18,69 @@ use indoc::indoc;
 
 #[test]
 fn empty_matcher_matches_empty_tuple() -> Result<()> {
-    verify_that!((), tuple!())
+    verify_that!((), ())
 }
 
 #[test]
 fn singleton_matcher_matches_matching_singleton_tuple() -> Result<()> {
-    verify_that!((123,), tuple!(eq(123)))
-}
-
-#[test]
-fn singleton_matcher_with_trailing_comma_matches_matching_singleton_tuple() -> Result<()> {
-    verify_that!((123,), tuple!(eq(123),))
+    verify_that!((123,), (eq(123),))
 }
 
 #[test]
 fn singleton_matcher_does_not_match_non_matching_singleton_tuple() -> Result<()> {
-    verify_that!((123,), not(tuple!(eq(456))))
+    verify_that!((123,), not((eq(456),)))
 }
 
 #[test]
 fn pair_matcher_matches_matching_pair_tuple() -> Result<()> {
-    verify_that!((123, 456), tuple!(eq(123), eq(456)))
+    verify_that!((123, 456), (eq(123), eq(456)))
 }
 
 #[test]
 fn pair_matcher_matches_matching_pair_tuple_with_different_types() -> Result<()> {
-    verify_that!((123, "A string"), tuple!(eq(123), eq("A string")))
+    verify_that!((123, "A string"), (eq(123), eq("A string")))
 }
 
 #[test]
 fn pair_matcher_with_trailing_comma_matches_matching_pair_tuple() -> Result<()> {
-    verify_that!((123, 456), tuple!(eq(123), eq(456),))
+    verify_that!((123, 456), (eq(123), eq(456),))
 }
 
 #[test]
 fn tuple_matcher_matches_matching_3_tuple() -> Result<()> {
-    verify_that!((1, 2, 3), tuple!(eq(1), eq(2), eq(3)))
+    verify_that!((1, 2, 3), (eq(1), eq(2), eq(3)))
 }
 
 #[test]
 fn tuple_matcher_matches_matching_4_tuple() -> Result<()> {
-    verify_that!((1, 2, 3, 4), tuple!(eq(1), eq(2), eq(3), eq(4)))
+    verify_that!((1, 2, 3, 4), (eq(1), eq(2), eq(3), eq(4)))
 }
 
 #[test]
 fn tuple_matcher_matches_matching_5_tuple() -> Result<()> {
-    verify_that!((1, 2, 3, 4, 5), tuple!(eq(1), eq(2), eq(3), eq(4), eq(5)))
+    verify_that!((1, 2, 3, 4, 5), (eq(1), eq(2), eq(3), eq(4), eq(5)))
 }
 
 #[test]
 fn tuple_matcher_matches_matching_6_tuple() -> Result<()> {
-    verify_that!((1, 2, 3, 4, 5, 6), tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6)))
+    verify_that!((1, 2, 3, 4, 5, 6), (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6)))
 }
 
 #[test]
 fn tuple_matcher_matches_matching_7_tuple() -> Result<()> {
-    verify_that!((1, 2, 3, 4, 5, 6, 7), tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7)))
+    verify_that!((1, 2, 3, 4, 5, 6, 7), (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7)))
 }
 
 #[test]
 fn tuple_matcher_matches_matching_8_tuple() -> Result<()> {
-    verify_that!(
-        (1, 2, 3, 4, 5, 6, 7, 8),
-        tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8))
-    )
+    verify_that!((1, 2, 3, 4, 5, 6, 7, 8), (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8)))
 }
 
 #[test]
 fn tuple_matcher_matches_matching_9_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8, 9),
-        tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9))
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9))
     )
 }
 
@@ -96,7 +88,7 @@ fn tuple_matcher_matches_matching_9_tuple() -> Result<()> {
 fn tuple_matcher_matches_matching_10_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
-        tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10))
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10))
     )
 }
 
@@ -104,7 +96,7 @@ fn tuple_matcher_matches_matching_10_tuple() -> Result<()> {
 fn tuple_matcher_matches_matching_11_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-        tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10), eq(11))
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10), eq(11))
     )
 }
 
@@ -112,53 +104,40 @@ fn tuple_matcher_matches_matching_11_tuple() -> Result<()> {
 fn tuple_matcher_matches_matching_12_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
-        tuple!(
-            eq(1),
-            eq(2),
-            eq(3),
-            eq(4),
-            eq(5),
-            eq(6),
-            eq(7),
-            eq(8),
-            eq(9),
-            eq(10),
-            eq(11),
-            eq(12)
-        )
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10), eq(11), eq(12))
     )
 }
 
 #[test]
 fn tuple_matcher_with_trailing_comma_matches_matching_3_tuple() -> Result<()> {
-    verify_that!((1, 2, 3), tuple!(eq(1), eq(2), eq(3),))
+    verify_that!((1, 2, 3), (eq(1), eq(2), eq(3),))
 }
 
 #[test]
 fn tuple_matcher_with_trailing_comma_matches_matching_4_tuple() -> Result<()> {
-    verify_that!((1, 2, 3, 4), tuple!(eq(1), eq(2), eq(3), eq(4),))
+    verify_that!((1, 2, 3, 4), (eq(1), eq(2), eq(3), eq(4),))
 }
 
 #[test]
 fn tuple_matcher_with_trailing_comma_matches_matching_5_tuple() -> Result<()> {
-    verify_that!((1, 2, 3, 4, 5), tuple!(eq(1), eq(2), eq(3), eq(4), eq(5),))
+    verify_that!((1, 2, 3, 4, 5), (eq(1), eq(2), eq(3), eq(4), eq(5),))
 }
 
 #[test]
 fn tuple_matcher_with_trailing_comma_matches_matching_6_tuple() -> Result<()> {
-    verify_that!((1, 2, 3, 4, 5, 6), tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6),))
+    verify_that!((1, 2, 3, 4, 5, 6), (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6),))
 }
 
 #[test]
 fn tuple_matcher_with_trailing_comma_matches_matching_7_tuple() -> Result<()> {
-    verify_that!((1, 2, 3, 4, 5, 6, 7), tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7),))
+    verify_that!((1, 2, 3, 4, 5, 6, 7), (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7),))
 }
 
 #[test]
 fn tuple_matcher_with_trailing_comma_matches_matching_8_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8),
-        tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8),)
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8),)
     )
 }
 
@@ -166,7 +145,7 @@ fn tuple_matcher_with_trailing_comma_matches_matching_8_tuple() -> Result<()> {
 fn tuple_matcher_with_trailing_comma_matches_matching_9_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8, 9),
-        tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9),)
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9),)
     )
 }
 
@@ -174,7 +153,7 @@ fn tuple_matcher_with_trailing_comma_matches_matching_9_tuple() -> Result<()> {
 fn tuple_matcher_with_trailing_comma_matches_matching_10_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
-        tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10),)
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10),)
     )
 }
 
@@ -182,7 +161,7 @@ fn tuple_matcher_with_trailing_comma_matches_matching_10_tuple() -> Result<()> {
 fn tuple_matcher_with_trailing_comma_matches_matching_11_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-        tuple!(eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10), eq(11),)
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10), eq(11),)
     )
 }
 
@@ -190,27 +169,14 @@ fn tuple_matcher_with_trailing_comma_matches_matching_11_tuple() -> Result<()> {
 fn tuple_matcher_with_trailing_comma_matches_matching_12_tuple() -> Result<()> {
     verify_that!(
         (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
-        tuple!(
-            eq(1),
-            eq(2),
-            eq(3),
-            eq(4),
-            eq(5),
-            eq(6),
-            eq(7),
-            eq(8),
-            eq(9),
-            eq(10),
-            eq(11),
-            eq(12),
-        )
+        (eq(1), eq(2), eq(3), eq(4), eq(5), eq(6), eq(7), eq(8), eq(9), eq(10), eq(11), eq(12),)
     )
 }
 
 #[test]
 fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
     verify_that!(
-        tuple!(eq(1)).describe(MatcherResult::Matches),
+        (eq(1),).describe(MatcherResult::Matches),
         eq(indoc!(
             "
             is a tuple whose values respectively match:
@@ -223,7 +189,7 @@ fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
 #[test]
 fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
-        tuple!(eq(1)).describe(MatcherResult::DoesNotMatch),
+        (eq(1),).describe(MatcherResult::DoesNotMatch),
         eq(indoc!(
             "
             is a tuple whose values do not respectively match:
@@ -236,7 +202,7 @@ fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
 #[test]
 fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
     verify_that!(
-        tuple!(eq(1), eq(2)).describe(MatcherResult::Matches),
+        (eq(1), eq(2)).describe(MatcherResult::Matches),
         eq(indoc!(
             "
             is a tuple whose values respectively match:
@@ -250,7 +216,7 @@ fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
 #[test]
 fn tuple_matcher_2_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
-        tuple!(eq(1), eq(2)).describe(MatcherResult::DoesNotMatch),
+        (eq(1), eq(2)).describe(MatcherResult::DoesNotMatch),
         eq(indoc!(
             "
             is a tuple whose values do not respectively match:
@@ -264,7 +230,7 @@ fn tuple_matcher_2_has_correct_description_for_mismatch() -> Result<()> {
 #[test]
 fn describe_match_shows_which_tuple_element_did_not_match() -> Result<()> {
     verify_that!(
-        tuple!(eq(1), eq(2)).explain_match(&(1, 3)),
+        (eq(1), eq(2)).explain_match(&(1, 3)),
         displays_as(eq(indoc!(
             "
             which is a tuple whose values do not respectively match:
@@ -279,7 +245,7 @@ fn describe_match_shows_which_tuple_element_did_not_match() -> Result<()> {
 #[test]
 fn describe_match_shows_which_two_tuple_elements_did_not_match() -> Result<()> {
     verify_that!(
-        tuple!(eq(1), eq(2)).explain_match(&(2, 3)),
+        (eq(1), eq(2)).explain_match(&(2, 3)),
         displays_as(eq(indoc!(
             "
             which is a tuple whose values do not respectively match:


### PR DESCRIPTION
This means that one can just put a bunch of matchers into a tuple and the result will itself be a matcher against corresponding tuples:

```
let value = (1, 2);
verify_that!(value, (eq(1), eq(2)))
```

There is no need for a separate macro for this, since one can implement `Matcher` for a tuple of matchers directly.

This is a breaking change, since it eliminates the `tuple!` macro. To port existing code, one just removes the call to `tuple!` and adds a trailing comma if necessary.