### PR TITLE
Do not rely on a color term crate to generate ANSI character

### DIFF
--- a/googletest/Cargo.toml
+++ b/googletest/Cargo.toml
@@ -32,7 +32,6 @@ authors = [
 
 [dependencies]
 googletest_macro = { path = "../googletest_macro", version = "0.9.0" }
-ansi_term = "0.12.0"
 anyhow = { version = "1", optional = true }
 num-traits = "0.2.15"
 regex = "1.6.0"

--- a/googletest/src/matcher_support/summarize_diff.rs
+++ b/googletest/src/matcher_support/summarize_diff.rs
@@ -16,8 +16,6 @@
 use std::borrow::Cow;
 use std::fmt::{Display, Write};
 
-use nu_ansi_term::{Color, Style};
-
 use crate::matcher_support::edit_distance;
 
 /// Environment variable controlling the usage of ansi color in difference
@@ -154,26 +152,32 @@ fn compress_common_lines(common_lines: Vec<&str>) -> String {
     truncated_lines
 }
 
+// See
 struct LineStyle {
-    ansi: Style,
+    ansi_prefix: &'static str,
+    ansi_suffix: &'static str,
     header: char,
 }
 
 impl LineStyle {
+    // Font in red and bold
     fn extra_actual_style() -> Self {
-        Self { ansi: Style::new().fg(Color::Red).bold(), header: '-' }
+        Self { ansi_prefix: "\x1B[1;31m", ansi_suffix: "\x1B[0m", header: '-' }
     }
 
+    // Font in green and bold
     fn extra_expected_style() -> Self {
-        Self { ansi: Style::new().fg(Color::Green).bold(), header: '+' }
+        Self { ansi_prefix: "\x1B[1;32m", ansi_suffix: "\x1B[0m", header: '+' }
     }
 
+    // Font in italic
     fn comment_style() -> Self {
-        Self { ansi: Style::new().italic(), header: ' ' }
+        Self { ansi_prefix: "\x1B[3m", ansi_suffix: "\x1B[0m", header: ' ' }
     }
 
+    // No ansi styling
     fn unchanged_style() -> Self {
-        Self { ansi: Style::new(), header: ' ' }
+        Self { ansi_prefix: "", ansi_suffix: "", header: ' ' }
     }
 
     fn style(self, line: &str) -> StyledLine<'_> {
@@ -192,10 +196,7 @@ impl<'a> Display for StyledLine<'a> {
             write!(
                 f,
                 "{}{}{}{}",
-                self.style.header,
-                self.style.ansi.prefix(),
-                self.line,
-                self.style.ansi.suffix()
+                self.style.header, self.style.ansi_prefix, self.line, self.style.ansi_suffix
             )
         } else {
             write!(f, "{}{}", self.style.header, self.line)


### PR DESCRIPTION
Do not rely on a ANSI crate but just use the ANSI character hardcoded.

* ansi-term is not maintained anymore
* nu-ansi-term requires a Rust version higher than our current minimum version
* overall, we are not doing anything too fancy with colors.
  * this may change in the future, which can lead to the need for a crate which would support our requirements.