### PR TITLE
Clarify the behaviour of fatal and non-fatal assertions in the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,23 @@ It must return [`Result<()>`].
 use googletest::prelude::*;
 
 #[googletest::test]
-fn more_than_one_failure() -> Result<()> {
+fn failing_non_fatal_assertion() -> Result<()> {
     let value = 2;
     expect_that!(value, eq(3));  // Just marks the test as having failed.
-    verify_that!(value, eq(2))?;  // Passes, but the test already failed.
+    verify_that!(value, eq(2))?;  // Passes, so does not abort the test.
+    Ok(())        // Because of the failing expect_that! call above, the
+                  // test fails despite returning Ok(())
+}
+```
+
+```rust
+use googletest::prelude::*;
+
+#[googletest::test]
+fn failing_fatal_assertion_after_non_fatal_assertion() -> Result<()> {
+    let value = 2;
+    verify_that!(value, eq(3))?; // Fails and aborts the test.
+    expect_that!(value, eq(3));  // Never executes, since the test already aborted.
     Ok(())
 }
 ```

--- a/googletest/crate_docs.md
+++ b/googletest/crate_docs.md
@@ -298,10 +298,24 @@ use googletest::prelude::*;
 # /* Make sure this also compiles as a doctest.
 #[googletest::test]
 # */
-fn more_than_one_failure() -> Result<()> {
+fn failing_non_fatal_assertion() -> Result<()> {
     let value = 2;
     expect_that!(value, eq(3));  // Just marks the test as having failed.
-    verify_that!(value, eq(2))?;  // Passes, but the test already failed.
+    verify_that!(value, eq(2))?;  // Passes, so does not abort the test.
+    Ok(())        // Because of the failing expect_that! call above, the
+                  // test fails despite returning Ok(())
+}
+```
+
+```no_run
+use googletest::prelude::*;
+
+#[googletest::test]
+fn failing_fatal_assertion_after_non_fatal_assertion() -> Result<()> {
+    let value = 2;
+    expect_that!(value, eq(2));  // Passes; test still considered passing.
+    verify_that!(value, eq(3))?; // Fails and aborts the test.
+    expect_that!(value, eq(3));  // Never executes, since the test already aborted.
     Ok(())
 }
 ```


### PR DESCRIPTION
This adjusts the text to make it clear that using the ? operator on a `verify_that!` result only causes the test to abort if *that assertion* fails and not if there are previous failing non-fatal assertions. It also adds a further example to illustrate the relationship between fatal and non-fatal assertions.