### PR TITLE
Use the supports-color crate to determine whether to produce coloured diffs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     name: test / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable, nightly, beta]
+        toolchain: [stable, 1.64.0, nightly, beta]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.toolchain }}
@@ -62,7 +62,7 @@ jobs:
     name: test (no default features) / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable, 1.59]
+        toolchain: [stable]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.toolchain }}
@@ -80,7 +80,7 @@ jobs:
     name: integration-test / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable, 1.59.0, nightly, beta]
+        toolchain: [stable, 1.64.0, nightly, beta]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.toolchain }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This library brings the rich assertion types of Google's C++ testing library
  * A new set of assertion macros offering similar functionality to those of
    [GoogleTest](https://google.github.io/googletest/primer.html#assertions).
 
-**The minimum supported Rust version is 1.59**. We recommend using at least
+**The minimum supported Rust version is 1.64**. We recommend using at least
 version 1.66 for the best developer experience.
 
 > :warning: The API is not fully stable and may still be changed until we
@@ -284,9 +284,9 @@ displayed, we recommend setting those variables in the personal
 
 ### Configuration variable list
 
-| Variable name       | Description                                        |
-| ------------------- | -------------------------------------------------- |
-| GTEST_RUST_NO_COLOR | If set to any value, disables ANSI output from the failure message. This is useful when the failure description is piped to a file or another process. |
+| Variable name | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| NO_COLOR      | Disables coloured output. See <https://no-color.org/>. |
 
 ## Contributing Changes
 

--- a/googletest/Cargo.toml
+++ b/googletest/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/google/googletest-rust"
 readme = "../README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.64.0"
 authors = [
   "Bradford Hovinen <hovinen@google.com>",
   "Bastien Jacot-Guillarmod <bjacotg@google.com>",
@@ -34,8 +34,9 @@ authors = [
 googletest_macro = { path = "../googletest_macro", version = "0.9.0" }
 anyhow = { version = "1", optional = true }
 num-traits = "0.2.15"
-regex = "1.6.0"
 proptest = { version = "1.2.0", optional = true }
+regex = "1.6.0"
+supports-color = "2.0.0"
 
 [dev-dependencies]
 indoc = "2"

--- a/googletest/config.toml
+++ b/googletest/config.toml
@@ -1,0 +1,2 @@
+[env]
+NO_COLOR = "1"

--- a/googletest/src/matcher_support/summarize_diff.rs
+++ b/googletest/src/matcher_support/summarize_diff.rs
@@ -14,14 +14,9 @@
 
 #![doc(hidden)]
 
+use crate::matcher_support::edit_distance;
 use std::borrow::Cow;
 use std::fmt::{Display, Write};
-
-use crate::matcher_support::edit_distance;
-
-/// Environment variable controlling the usage of ansi color in difference
-/// summary.
-const NO_COLOR_VAR: &str = "GTEST_RUST_NO_COLOR";
 
 /// Returns a string describing how the expected and actual lines differ.
 ///
@@ -195,7 +190,7 @@ struct StyledLine<'a> {
 
 impl<'a> Display for StyledLine<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if std::env::var(NO_COLOR_VAR).is_err() {
+        if supports_color::on_cached(supports_color::Stream::Stdout).is_some() {
             write!(
                 f,
                 "{}{}{}{}",
@@ -212,31 +207,6 @@ mod tests {
     use super::*;
     use crate::{matcher_support::edit_distance::Mode, prelude::*};
     use indoc::indoc;
-    use serial_test::serial;
-
-    #[must_use]
-    fn remove_var() -> TempVar {
-        let old_value = std::env::var(NO_COLOR_VAR);
-        std::env::remove_var(NO_COLOR_VAR);
-        TempVar(old_value.ok())
-    }
-
-    #[must_use]
-    fn set_var(var: &str) -> TempVar {
-        let old_value = std::env::var(NO_COLOR_VAR);
-        std::env::set_var(NO_COLOR_VAR, var);
-        TempVar(old_value.ok())
-    }
-    struct TempVar(Option<String>);
-
-    impl Drop for TempVar {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(old_var) => std::env::set_var(NO_COLOR_VAR, old_var),
-                None => std::env::remove_var(NO_COLOR_VAR),
-            }
-        }
-    }
 
     // Make a long text with each element of the iterator on one line.
     // `collection` must contains at least one element.
@@ -277,30 +247,8 @@ mod tests {
     }
 
     #[test]
-    #[serial]
-    fn create_diff_exact_small_difference() -> Result<()> {
-        let _cleanup = remove_var();
-
-        verify_that!(
-            create_diff(&build_text(1..50), &build_text(1..51), Mode::Exact),
-            eq(indoc! {
-                "
-
-                Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
-                 1
-                 2
-                 \x1B[3m<---- 45 common lines omitted ---->\x1B[0m
-                 48
-                 49
-                +\x1B[1;32m50\x1B[0m"
-            })
-        )
-    }
-
-    #[test]
-    #[serial]
     fn create_diff_exact_small_difference_no_color() -> Result<()> {
-        let _cleanup = set_var("NO_COLOR");
+        std::env::set_var("NO_COLOR", "1");
 
         verify_that!(
             create_diff(&build_text(1..50), &build_text(1..51), Mode::Exact),

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -108,10 +108,10 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                     which displays as a string which isn't equal to \"123\\n345\"
-                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+                    Difference(-actual / +expected):
                      123
-                    -\x1B[1;31m234\x1B[0m
-                    +\x1B[1;32m345\x1B[0m
+                    -234
+                    +345
                 "
             ))))
         )

--- a/googletest/src/matchers/eq_deref_of_matcher.rs
+++ b/googletest/src/matchers/eq_deref_of_matcher.rs
@@ -138,12 +138,12 @@ mod tests {
             "
             Actual: Strukt { int: 123, string: \"something\" },
               which isn't equal to Strukt { int: 321, string: \"someone\" }
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              Strukt {
-            -\x1B[1;31m    int: 123,\x1B[0m
-            +\x1B[1;32m    int: 321,\x1B[0m
-            -\x1B[1;31m    string: \"something\",\x1B[0m
-            +\x1B[1;32m    string: \"someone\",\x1B[0m
+            -    int: 123,
+            +    int: 321,
+            -    string: \"something\",
+            +    string: \"someone\",
              }
             "})))
         )

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -178,12 +178,12 @@ mod tests {
             "
             Actual: Strukt { int: 123, string: \"something\" },
               which isn't equal to Strukt { int: 321, string: \"someone\" }
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              Strukt {
-            -\x1B[1;31m    int: 123,\x1B[0m
-            +\x1B[1;32m    int: 321,\x1B[0m
-            -\x1B[1;31m    string: \"something\",\x1B[0m
-            +\x1B[1;32m    string: \"someone\",\x1B[0m
+            -    int: 123,
+            +    int: 321,
+            -    string: \"something\",
+            +    string: \"someone\",
              }
             "})))
         )
@@ -200,12 +200,12 @@ mod tests {
             Expected: is equal to [1, 3, 4]
             Actual: [1, 2, 3],
               which isn't equal to [1, 3, 4]
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
                  1,
-            -\x1B[1;31m    2,\x1B[0m
+            -    2,
                  3,
-            +\x1B[1;32m    4,\x1B[0m
+            +    4,
              ]
             "})))
         )
@@ -222,12 +222,12 @@ mod tests {
             Expected: is equal to [1, 3, 5]
             Actual: [1, 2, 3, 4, 5],
               which isn't equal to [1, 3, 5]
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
                  1,
-            -\x1B[1;31m    2,\x1B[0m
+            -    2,
                  3,
-            -\x1B[1;31m    4,\x1B[0m
+            -    4,
                  5,
              ]
             "})))
@@ -241,17 +241,17 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
-            -\x1B[1;31m    1,\x1B[0m
-            -\x1B[1;31m    2,\x1B[0m
+            -    1,
+            -    2,
                  3,
                  4,
-             \x1B[3m<---- 43 common lines omitted ---->\x1B[0m
+             <---- 43 common lines omitted ---->
                  48,
                  49,
-            +\x1B[1;32m    50,\x1B[0m
-            +\x1B[1;32m    51,\x1B[0m
+            +    50,
+            +    51,
              ]"})))
         )
     }
@@ -263,17 +263,17 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
-            -\x1B[1;31m    1,\x1B[0m
-            -\x1B[1;31m    2,\x1B[0m
+            -    1,
+            -    2,
                  3,
                  4,
                  5,
                  6,
                  7,
-            +\x1B[1;32m    8,\x1B[0m
-            +\x1B[1;32m    9,\x1B[0m
+            +    8,
+            +    9,
              ]"})))
         )
     }
@@ -285,14 +285,14 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
                  1,
-             \x1B[3m<---- 46 common lines omitted ---->\x1B[0m
+             <---- 46 common lines omitted ---->
                  48,
                  49,
-            +\x1B[1;32m    50,\x1B[0m
-            +\x1B[1;32m    51,\x1B[0m
+            +    50,
+            +    51,
              ]"})))
         )
     }
@@ -304,13 +304,13 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
-            -\x1B[1;31m    1,\x1B[0m
-            -\x1B[1;31m    2,\x1B[0m
+            -    1,
+            -    2,
                  3,
                  4,
-             \x1B[3m<---- 46 common lines omitted ---->\x1B[0m
+             <---- 46 common lines omitted ---->
                  51,
              ]"})))
         )
@@ -357,8 +357,8 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                  First line
-                -\x1B[1;31mSecond line\x1B[0m
-                +\x1B[1;32mSecond lines\x1B[0m
+                -Second line
+                +Second lines
                  Third line
                 "
             ))))
@@ -380,9 +380,7 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(not(contains_substring(
-                "Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):"
-            ))))
+            err(displays_as(not(contains_substring("Difference(-actual / +expected):"))))
         )
     }
 
@@ -401,9 +399,7 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(not(contains_substring(
-                "Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):"
-            ))))
+            err(displays_as(not(contains_substring("Difference(-actual / +expected):"))))
         )
     }
 }

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -726,8 +726,8 @@ mod tests {
     }
 
     #[test]
-    fn matches_string_containing_expected_value_in_contains_mode_while_ignoring_ascii_case()
-    -> Result<()> {
+    fn matches_string_containing_expected_value_in_contains_mode_while_ignoring_ascii_case(
+    ) -> Result<()> {
         verify_that!("Some string", contains_substring("STR").ignoring_ascii_case())
     }
 
@@ -876,8 +876,8 @@ mod tests {
     }
 
     #[test]
-    fn describes_itself_for_matching_result_ignoring_ascii_case_and_leading_whitespace()
-    -> Result<()> {
+    fn describes_itself_for_matching_result_ignoring_ascii_case_and_leading_whitespace(
+    ) -> Result<()> {
         let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string")
             .ignoring_leading_whitespace()
             .ignoring_ascii_case();
@@ -974,8 +974,8 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                  First line
-                -\x1B[1;31mSecond line\x1B[0m
-                +\x1B[1;32mSecond lines\x1B[0m
+                -Second line
+                +Second lines
                  Third line
                 "
             ))))
@@ -1007,18 +1007,18 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    -\x1B[1;31mSecond line\x1B[0m
-                    +\x1B[1;32mSecond lines\x1B[0m
+                    -Second line
+                    +Second lines
                      Third line
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                     <---- remaining lines omitted ---->
                 "
             ))))
         )
     }
 
     #[test]
-    fn match_explanation_for_starts_with_includes_both_versions_of_differing_last_line()
-    -> Result<()> {
+    fn match_explanation_for_starts_with_includes_both_versions_of_differing_last_line(
+    ) -> Result<()> {
         let result = verify_that!(
             indoc!(
                 "
@@ -1040,9 +1040,9 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    -\x1B[1;31mSecond line\x1B[0m
-                    +\x1B[1;32mSecond lines\x1B[0m
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                    -Second line
+                    +Second lines
+                     <---- remaining lines omitted ---->
                 "
             ))))
         )
@@ -1072,11 +1072,11 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                    Difference(-actual / +expected):
+                     <---- remaining lines omitted ---->
                      Second line
-                    +\x1B[1;32mThird lines\x1B[0m
-                    -\x1B[1;31mThird line\x1B[0m
+                    +Third lines
+                    -Third line
                      Fourth line
                 "
             ))))
@@ -1109,20 +1109,20 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                    Difference(-actual / +expected):
+                     <---- remaining lines omitted ---->
                      Second line
-                    +\x1B[1;32mThird lines\x1B[0m
-                    -\x1B[1;31mThird line\x1B[0m
+                    +Third lines
+                    -Third line
                      Fourth line
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m"
+                     <---- remaining lines omitted ---->"
             ))))
         )
     }
 
     #[test]
-    fn match_explanation_for_contains_substring_shows_diff_when_first_and_last_line_are_incomplete()
-    -> Result<()> {
+    fn match_explanation_for_contains_substring_shows_diff_when_first_and_last_line_are_incomplete(
+    ) -> Result<()> {
         let result = verify_that!(
             indoc!(
                 "
@@ -1146,16 +1146,16 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
-                    +\x1B[1;32mline\x1B[0m
-                    -\x1B[1;31mSecond line\x1B[0m
+                    Difference(-actual / +expected):
+                     <---- remaining lines omitted ---->
+                    +line
+                    -Second line
                      Third line
-                    +\x1B[1;32mFoorth line\x1B[0m
-                    -\x1B[1;31mFourth line\x1B[0m
-                    +\x1B[1;32mFifth\x1B[0m
-                    -\x1B[1;31mFifth line\x1B[0m
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                    +Foorth line
+                    -Fourth line
+                    +Fifth
+                    -Fifth line
+                     <---- remaining lines omitted ---->
                 "
             ))))
         )
@@ -1186,10 +1186,10 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    -\x1B[1;31mSecond line\x1B[0m
-                    +\x1B[1;32mSecond lines\x1B[0m
+                    -Second line
+                    +Second lines
                      Third line
-                    -\x1B[1;31mFourth line\x1B[0m
+                    -Fourth line
                 "
             ))))
         )
@@ -1209,9 +1209,7 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(not(contains_substring(
-                "Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):"
-            ))))
+            err(displays_as(not(contains_substring("Difference(-actual / +expected):"))))
         )
     }
 
@@ -1230,9 +1228,7 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(not(contains_substring(
-                "Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):"
-            ))))
+            err(displays_as(not(contains_substring("Difference(-actual / +expected):"))))
         )
     }
 }

--- a/googletest/tests/colourised_diff_test.rs
+++ b/googletest/tests/colourised_diff_test.rs
@@ -1,0 +1,51 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use googletest::prelude::*;
+use indoc::indoc;
+use std::fmt::{Display, Write};
+
+// Make a long text with each element of the iterator on one line.
+// `collection` must contains at least one element.
+fn build_text<T: Display>(mut collection: impl Iterator<Item = T>) -> String {
+    let mut text = String::new();
+    write!(&mut text, "{}", collection.next().expect("Provided collection without elements"))
+        .unwrap();
+    for item in collection {
+        write!(&mut text, "\n{}", item).unwrap();
+    }
+    text
+}
+
+#[test]
+fn create_diff_exact_small_difference() -> Result<()> {
+    std::env::remove_var("NO_COLOR");
+
+    let result = verify_that!(build_text(1..50), eq(build_text(1..51)));
+
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc! {
+            "
+
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+             1
+             2
+             \x1B[3m<---- 45 common lines omitted ---->\x1B[0m
+             48
+             49
+            +\x1B[1;32m50\x1B[0m"
+        })))
+    )
+}

--- a/googletest/tests/lib.rs
+++ b/googletest/tests/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod all_matcher_test;
+mod colourised_diff_test;
 mod composition_test;
 mod elements_are_matcher_test;
 mod field_matcher_test;

--- a/googletest/tests/no_color_test.rs
+++ b/googletest/tests/no_color_test.rs
@@ -1,0 +1,53 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "supports-color")]
+
+use googletest::prelude::*;
+use indoc::indoc;
+use std::fmt::{Display, Write};
+
+// Make a long text with each element of the iterator on one line.
+// `collection` must contains at least one element.
+fn build_text<T: Display>(mut collection: impl Iterator<Item = T>) -> String {
+    let mut text = String::new();
+    write!(&mut text, "{}", collection.next().expect("Provided collection without elements"))
+        .unwrap();
+    for item in collection {
+        write!(&mut text, "\n{}", item).unwrap();
+    }
+    text
+}
+
+#[test]
+fn create_diff_exact_small_difference_no_color() -> Result<()> {
+    std::env::set_var("NO_COLOR", "1");
+
+    let result = verify_that!(build_text(1..50), eq(build_text(1..51)));
+
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc! {
+            "
+
+            Difference(-actual / +expected):
+             1
+             2
+             <---- 45 common lines omitted ---->
+             48
+             49
+            +50"
+        })))
+    )
+}


### PR DESCRIPTION
This outsources some of the tricky logic for determining whether to produce ANSI sequences into a separate crate which serves as a source of truth.

This also removes the ANSI colour sequences from nearly all tests. It creates two integration tests which specifically test the colourised output respectively the behaviour of the environment variable `NO_COLOR`. Otherwise, it globally sets `NO_COLOR` to suppress colourised output. This greatly reduces the noise in the existing test assertions and makes sure the tests continue to be compatible with all environments.

The environment variable `GTEST_RUST_NO_COLOR` is hereby no longer supported. Instead the more standard variable `NO_COLOR` has the same effect. See <http://no-color.org>.