### PR TITLE
Add support for using `is_terminal` and environment variables to determine whether to output ANSI colour sequences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,9 +297,10 @@ displayed, we recommend setting those variables in the personal
 
 ### Configuration variable list
 
-| Variable name       | Description                                        |
-| ------------------- | -------------------------------------------------- |
-| GTEST_RUST_NO_COLOR | If set to any value, disables ANSI output from the failure message. This is useful when the failure description is piped to a file or another process. |
+| Variable name | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| NO_COLOR      | Disables coloured output. See <https://no-color.org/>.  |
+| FORCE_COLOR   | Forces colours even when the output is piped to a file. |
 
 ## Contributing Changes
 

--- a/googletest/Cargo.toml
+++ b/googletest/Cargo.toml
@@ -34,8 +34,9 @@ authors = [
 googletest_macro = { path = "../googletest_macro", version = "0.9.0" }
 anyhow = { version = "1", optional = true }
 num-traits = "0.2.15"
-regex = "1.6.0"
 proptest = { version = "1.2.0", optional = true }
+regex = "1.6.0"
+rustversion = "1.0.14"
 
 [dev-dependencies]
 indoc = "2"

--- a/googletest/config.toml
+++ b/googletest/config.toml
@@ -1,0 +1,2 @@
+[env]
+NO_COLOR = "1"

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -108,10 +108,10 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                     which displays as a string which isn't equal to \"123\\n345\"
-                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+                    Difference(-actual / +expected):
                      123
-                    -\x1B[1;31m234\x1B[0m
-                    +\x1B[1;32m345\x1B[0m
+                    -234
+                    +345
                 "
             ))))
         )

--- a/googletest/src/matchers/eq_deref_of_matcher.rs
+++ b/googletest/src/matchers/eq_deref_of_matcher.rs
@@ -138,12 +138,12 @@ mod tests {
             "
             Actual: Strukt { int: 123, string: \"something\" },
               which isn't equal to Strukt { int: 321, string: \"someone\" }
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              Strukt {
-            -\x1B[1;31m    int: 123,\x1B[0m
-            +\x1B[1;32m    int: 321,\x1B[0m
-            -\x1B[1;31m    string: \"something\",\x1B[0m
-            +\x1B[1;32m    string: \"someone\",\x1B[0m
+            -    int: 123,
+            +    int: 321,
+            -    string: \"something\",
+            +    string: \"someone\",
              }
             "})))
         )

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -178,12 +178,12 @@ mod tests {
             "
             Actual: Strukt { int: 123, string: \"something\" },
               which isn't equal to Strukt { int: 321, string: \"someone\" }
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              Strukt {
-            -\x1B[1;31m    int: 123,\x1B[0m
-            +\x1B[1;32m    int: 321,\x1B[0m
-            -\x1B[1;31m    string: \"something\",\x1B[0m
-            +\x1B[1;32m    string: \"someone\",\x1B[0m
+            -    int: 123,
+            +    int: 321,
+            -    string: \"something\",
+            +    string: \"someone\",
              }
             "})))
         )
@@ -200,12 +200,12 @@ mod tests {
             Expected: is equal to [1, 3, 4]
             Actual: [1, 2, 3],
               which isn't equal to [1, 3, 4]
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
                  1,
-            -\x1B[1;31m    2,\x1B[0m
+            -    2,
                  3,
-            +\x1B[1;32m    4,\x1B[0m
+            +    4,
              ]
             "})))
         )
@@ -222,12 +222,12 @@ mod tests {
             Expected: is equal to [1, 3, 5]
             Actual: [1, 2, 3, 4, 5],
               which isn't equal to [1, 3, 5]
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
                  1,
-            -\x1B[1;31m    2,\x1B[0m
+            -    2,
                  3,
-            -\x1B[1;31m    4,\x1B[0m
+            -    4,
                  5,
              ]
             "})))
@@ -241,17 +241,17 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
-            -\x1B[1;31m    1,\x1B[0m
-            -\x1B[1;31m    2,\x1B[0m
+            -    1,
+            -    2,
                  3,
                  4,
-             \x1B[3m<---- 43 common lines omitted ---->\x1B[0m
+             <---- 43 common lines omitted ---->
                  48,
                  49,
-            +\x1B[1;32m    50,\x1B[0m
-            +\x1B[1;32m    51,\x1B[0m
+            +    50,
+            +    51,
              ]"})))
         )
     }
@@ -263,17 +263,17 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
-            -\x1B[1;31m    1,\x1B[0m
-            -\x1B[1;31m    2,\x1B[0m
+            -    1,
+            -    2,
                  3,
                  4,
                  5,
                  6,
                  7,
-            +\x1B[1;32m    8,\x1B[0m
-            +\x1B[1;32m    9,\x1B[0m
+            +    8,
+            +    9,
              ]"})))
         )
     }
@@ -285,14 +285,14 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
                  1,
-             \x1B[3m<---- 46 common lines omitted ---->\x1B[0m
+             <---- 46 common lines omitted ---->
                  48,
                  49,
-            +\x1B[1;32m    50,\x1B[0m
-            +\x1B[1;32m    51,\x1B[0m
+            +    50,
+            +    51,
              ]"})))
         )
     }
@@ -304,13 +304,13 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+            Difference(-actual / +expected):
              [
-            -\x1B[1;31m    1,\x1B[0m
-            -\x1B[1;31m    2,\x1B[0m
+            -    1,
+            -    2,
                  3,
                  4,
-             \x1B[3m<---- 46 common lines omitted ---->\x1B[0m
+             <---- 46 common lines omitted ---->
                  51,
              ]"})))
         )
@@ -357,8 +357,8 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                  First line
-                -\x1B[1;31mSecond line\x1B[0m
-                +\x1B[1;32mSecond lines\x1B[0m
+                -Second line
+                +Second lines
                  Third line
                 "
             ))))
@@ -380,9 +380,7 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(not(contains_substring(
-                "Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):"
-            ))))
+            err(displays_as(not(contains_substring("Difference(-actual / +expected):"))))
         )
     }
 
@@ -401,9 +399,7 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(not(contains_substring(
-                "Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):"
-            ))))
+            err(displays_as(not(contains_substring("Difference(-actual / +expected):"))))
         )
     }
 }

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -974,8 +974,8 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                  First line
-                -\x1B[1;31mSecond line\x1B[0m
-                +\x1B[1;32mSecond lines\x1B[0m
+                -Second line
+                +Second lines
                  Third line
                 "
             ))))
@@ -1007,10 +1007,10 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    -\x1B[1;31mSecond line\x1B[0m
-                    +\x1B[1;32mSecond lines\x1B[0m
+                    -Second line
+                    +Second lines
                      Third line
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                     <---- remaining lines omitted ---->
                 "
             ))))
         )
@@ -1040,9 +1040,9 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    -\x1B[1;31mSecond line\x1B[0m
-                    +\x1B[1;32mSecond lines\x1B[0m
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                    -Second line
+                    +Second lines
+                     <---- remaining lines omitted ---->
                 "
             ))))
         )
@@ -1072,11 +1072,11 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                    Difference(-actual / +expected):
+                     <---- remaining lines omitted ---->
                      Second line
-                    +\x1B[1;32mThird lines\x1B[0m
-                    -\x1B[1;31mThird line\x1B[0m
+                    +Third lines
+                    -Third line
                      Fourth line
                 "
             ))))
@@ -1109,13 +1109,13 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                    Difference(-actual / +expected):
+                     <---- remaining lines omitted ---->
                      Second line
-                    +\x1B[1;32mThird lines\x1B[0m
-                    -\x1B[1;31mThird line\x1B[0m
+                    +Third lines
+                    -Third line
                      Fourth line
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m"
+                     <---- remaining lines omitted ---->"
             ))))
         )
     }
@@ -1146,16 +1146,16 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
-                    Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
-                    +\x1B[1;32mline\x1B[0m
-                    -\x1B[1;31mSecond line\x1B[0m
+                    Difference(-actual / +expected):
+                     <---- remaining lines omitted ---->
+                    +line
+                    -Second line
                      Third line
-                    +\x1B[1;32mFoorth line\x1B[0m
-                    -\x1B[1;31mFourth line\x1B[0m
-                    +\x1B[1;32mFifth\x1B[0m
-                    -\x1B[1;31mFifth line\x1B[0m
-                     \x1B[3m<---- remaining lines omitted ---->\x1B[0m
+                    +Foorth line
+                    -Fourth line
+                    +Fifth
+                    -Fifth line
+                     <---- remaining lines omitted ---->
                 "
             ))))
         )
@@ -1186,10 +1186,10 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                      First line
-                    -\x1B[1;31mSecond line\x1B[0m
-                    +\x1B[1;32mSecond lines\x1B[0m
+                    -Second line
+                    +Second lines
                      Third line
-                    -\x1B[1;31mFourth line\x1B[0m
+                    -Fourth line
                 "
             ))))
         )
@@ -1209,9 +1209,7 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(not(contains_substring(
-                "Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):"
-            ))))
+            err(displays_as(not(contains_substring("Difference(-actual / +expected):"))))
         )
     }
 
@@ -1230,9 +1228,7 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(not(contains_substring(
-                "Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):"
-            ))))
+            err(displays_as(not(contains_substring("Difference(-actual / +expected):"))))
         )
     }
 }

--- a/googletest/tests/colourised_diff_test.rs
+++ b/googletest/tests/colourised_diff_test.rs
@@ -1,0 +1,52 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use googletest::prelude::*;
+use indoc::indoc;
+use std::fmt::{Display, Write};
+
+// Make a long text with each element of the iterator on one line.
+// `collection` must contains at least one element.
+fn build_text<T: Display>(mut collection: impl Iterator<Item = T>) -> String {
+    let mut text = String::new();
+    write!(&mut text, "{}", collection.next().expect("Provided collection without elements"))
+        .unwrap();
+    for item in collection {
+        write!(&mut text, "\n{}", item).unwrap();
+    }
+    text
+}
+
+#[test]
+fn colors_appear_when_no_color_is_no_set_and_force_color_is_set() -> Result<()> {
+    std::env::remove_var("NO_COLOR");
+    std::env::set_var("FORCE_COLOR", "1");
+
+    let result = verify_that!(build_text(1..50), eq(build_text(1..51)));
+
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc! {
+            "
+
+            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+             1
+             2
+             \x1B[3m<---- 45 common lines omitted ---->\x1B[0m
+             48
+             49
+            +\x1B[1;32m50\x1B[0m"
+        })))
+    )
+}

--- a/googletest/tests/lib.rs
+++ b/googletest/tests/lib.rs
@@ -14,6 +14,7 @@
 
 mod all_matcher_test;
 mod any_matcher_test;
+mod colourised_diff_test;
 mod composition_test;
 mod elements_are_matcher_test;
 mod field_matcher_test;

--- a/googletest/tests/no_color_test.rs
+++ b/googletest/tests/no_color_test.rs
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "supports-color")]
+
+use googletest::prelude::*;
+use indoc::indoc;
+use std::fmt::{Display, Write};
+
+// Make a long text with each element of the iterator on one line.
+// `collection` must contains at least one element.
+fn build_text<T: Display>(mut collection: impl Iterator<Item = T>) -> String {
+    let mut text = String::new();
+    write!(&mut text, "{}", collection.next().expect("Provided collection without elements"))
+        .unwrap();
+    for item in collection {
+        write!(&mut text, "\n{}", item).unwrap();
+    }
+    text
+}
+
+#[test]
+fn colours_suppressed_when_both_no_color_and_force_color_are_set() -> Result<()> {
+    std::env::set_var("NO_COLOR", "1");
+    std::env::set_var("FORCE_COLOR", "1");
+
+    let result = verify_that!(build_text(1..50), eq(build_text(1..51)));
+
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc! {
+            "
+
+            Difference(-actual / +expected):
+             1
+             2
+             <---- 45 common lines omitted ---->
+             48
+             49
+            +50"
+        })))
+    )
+}


### PR DESCRIPTION
This makes use of the trait [`IsTerminal`](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html), stabilised in Rust 1.70. If the Rust version is at least 1.70, then the library uses this trait to detect whether stdout is a terminal and only outputs colours by default if that is the case. When used on prior Rust versions, the library does not detect whether the output is a terminal and defaults to not outputing colours.

This also introduces support for two environment variables to override the default behaviour defined above:

 * `NO_COLOR`, described in <http://no-color.org>.
 * `FORCE_COLOR`, which is supported by a range of tools such as [Node.js](https://nodejs.org/api/cli.html#force_color1-2-3).

The environment variable `GTEST_RUST_NO_COLOR` is hereby no longer supported.

This also removes the ANSI colour sequences from nearly all tests. It creates two integration tests which specifically test the colourised output respectively the behaviour of the environment variable `NO_COLOR`. Otherwise, it globally sets `NO_COLOR` to suppress colourised output. This greatly reduces the noise in the existing test assertions and makes sure the tests continue to be compatible with all environments.

Since the use of `IsTerminal` is optional and conditional on the Rust version, this does not change the minimum supported Rust version.