### PR TITLE
Switching the PartialEq bound in eq(...) for better compiler error

### DIFF
--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -82,11 +82,11 @@ pub struct EqMatcher<A: ?Sized, T> {
     phantom: PhantomData<A>,
 }
 
-impl<A: Debug + ?Sized, T: PartialEq<A> + Debug> Matcher for EqMatcher<A, T> {
+impl<A: Debug + ?Sized + PartialEq<T>, T: Debug> Matcher for EqMatcher<A, T> {
     type ActualT = A;
 
     fn matches(&self, actual: &A) -> MatcherResult {
-        (self.expected == *actual).into()
+        (*actual == self.expected).into()
     }
 
     fn describe(&self, matcher_result: MatcherResult) -> String {


### PR DESCRIPTION
Currently, in `eq(...)`, we are enforcing that `ExpectedT : PartialEq<ActualT>`. This does not generate the most helpful message. Consider the following example:

```
#[derive(PartialEq, Debug)]
struct A;

#[derive(PartialEq, Debug)]
struct ComparableWithA;

impl PartialEq<ComparableWithA> for A {
    fn eq(&self, other: &ComparableWithA) -> bool {
        true
    }
}

#[derive(PartialEq, Debug)]
struct B;

#[derive(PartialEq, Debug)]
struct ComparableWithB;

impl PartialEq<ComparableWithB> for B {
    fn eq(&self, other: &ComparableWithB) -> bool {
        true
    }
}

#[test]
fn compilation_error() -> Result<()> {
    verify_that!(A, eq(B))
}
```

The compiler message would be:
```
    = help: the trait `PartialEq<A>` is not implemented for `B`
    = help: the following other types implement trait `PartialEq<Rhs>`:
              <B as PartialEq>
              <B as PartialEq<ComparableWithB>>
```
This is not very helpful as we would like to know which types are comparable with `A`.

However, switching the bound to `ActualT : PartialEq<ExpectedT>` lead to more useful error message:

```   
 = help: the following other types implement trait `PartialEq<Rhs>`:
              <A as PartialEq>
              <A as PartialEq<ComparableWithA>>
```


DO NOT SUBMIT this currently break type deduction in gtest_rust unittest.