### PR TITLE
Support test functions returning () with `#[googletest::test]`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,21 @@ This is analogous to the `EXPECT_*` family of macros in GoogleTest.
 
 To make a non-fatal assertion, use the macro [`expect_that!`]. The test must
 also be marked with [`googletest::test`] instead of the Rust-standard `#[test]`.
-It must return [`Result<()>`].
+
+```rust
+use googletest::prelude::*;
+
+#[googletest::test]
+fn three_non_fatal_assertions() {
+    let value = 2;
+    expect_that!(value, eq(2));  // Passes; test still considered passing.
+    expect_that!(value, eq(3));  // Fails; logs failure and marks the test failed.
+    expect_that!(value, eq(4));  // A second failure, also logged.
+}
+```
+
+This can be used in the same tests as `verify_that!`, in which case the test
+function must also return [`Result<()>`]:
 
 ```rust
 use googletest::prelude::*;

--- a/googletest/crate_docs.md
+++ b/googletest/crate_docs.md
@@ -291,7 +291,22 @@ aborts.
 
 To make a non-fatal assertion, use the macro [`expect_that!`]. The test must
 also be marked with [`googletest::test`][test] instead of the Rust-standard
-`#[test]`. It must return [`Result<()>`].
+`#[test]`.
+
+```no_run
+use googletest::prelude::*;
+
+#[googletest::test]
+fn three_non_fatal_assertions() {
+    let value = 2;
+    expect_that!(value, eq(2));  // Passes; test still considered passing.
+    expect_that!(value, eq(3));  // Fails; logs failure and marks the test failed.
+    expect_that!(value, eq(4));  // A second failure, also logged.
+}
+```
+
+This can be used in the same tests as `verify_that!`, in which case the test
+function must also return [`Result<()>`]:
 
 ```no_run
 use googletest::prelude::*;

--- a/integration_tests/src/integration_tests.rs
+++ b/integration_tests/src/integration_tests.rs
@@ -50,6 +50,12 @@ mod tests {
         Ok(())
     }
 
+    #[googletest::test]
+    fn should_pass_with_expect_that_returning_unit() {
+        let value = 2;
+        expect_that!(value, eq(2));
+    }
+
     #[test]
     fn should_fail_on_assertion_failure() -> Result<()> {
         let status = run_external_process("simple_assertion_failure").status()?;


### PR DESCRIPTION
A test which only uses the `expect_*` family of assertions (thus requiring `#[googletest::test]`) will only ever return `Ok(())`. There is therefore no reason to require the function itself to return a `Result`. That requirement just creates unnecessary boilerplate.

This change modifies the `#[googletest::test]` implementation to remove the requirement that the return type be present. If it is present, then it must still be a `Result`.

The generated compiler error can no longer occur and is removed. It would be ideal to check whether the given return type is in fact a `Result` and return a compiler error if it is not, but that is beyond the scope of this change.