### PR TITLE
Fix the language of the documentation of the type alias `Result`.

### DIFF
--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -62,7 +62,10 @@ use internal::test_outcome::{TestAssertionFailure, TestOutcome};
 
 /// A `Result` whose `Err` variant indicates a test failure.
 ///
-/// All test functions should return `Result<()>`.
+/// The assertions [`verify_that!`][crate::verify_that],
+/// [`verify_pred!`][crate::verify_pred], and [`fail!`][crate::fail] evaluate
+/// to `Result<()>`. A test function may return `Result<()>` in combination with
+/// those macros to abort immediately on assertion failure.
 ///
 /// This can be used with subroutines which may cause the test to fatally fail
 /// and which return some value needed by the caller. For example:


### PR DESCRIPTION
The existing language stated that test functions *must* return `Result<()>`. This is not true in light of the `assert_*` family of macros and is no longer true when using `expect_*` in combination with `#[googletest::test]`. This change updates the docstring to indicate that a test function *may* return the type alias for fatal assertion failures and that some of the assertion macros evaluate to it.