### PR TITLE
Support trailing commas in the shorthand `element_are!` and `unordered_elements_are!` syntax.

### DIFF
--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -120,7 +120,7 @@
 /// not supported; see [Rust by Example](https://doc.rust-lang.org/rust-by-example/primitives/tuples.html#tuples).
 #[macro_export]
 macro_rules! verify_that {
-    ($actual:expr, [$($expecteds:expr),+]) => {
+    ($actual:expr, [$($expecteds:expr),+ $(,)?]) => {
         $crate::assertions::internal::check_matcher(
             &$actual,
             $crate::elements_are![$($expecteds),+],
@@ -128,7 +128,7 @@ macro_rules! verify_that {
             $crate::internal::source_location::SourceLocation::new(file!(), line!(), column!()),
         )
     };
-    ($actual:expr, {$($expecteds:expr),+}) => {
+    ($actual:expr, {$($expecteds:expr),+ $(,)?}) => {
         $crate::assertions::internal::check_matcher(
             &$actual,
             $crate::unordered_elements_are![$($expecteds),+],

--- a/integration_tests/src/integration_tests.rs
+++ b/integration_tests/src/integration_tests.rs
@@ -37,6 +37,17 @@ mod tests {
     }
 
     #[test]
+    fn verify_that_with_short_elements_are_syntax_supports_trailing_comma() -> Result<()> {
+        verify_that!(vec![1, 2], [eq(1), eq(2),])
+    }
+
+    #[test]
+    fn verify_that_with_short_unordered_elements_are_syntax_supports_trailing_comma() -> Result<()>
+    {
+        verify_that!(vec![1, 2], {eq(2), eq(1),})
+    }
+
+    #[test]
     fn should_pass_with_assert_that() -> Result<()> {
         let value = 2;
         assert_that!(value, eq(2));


### PR DESCRIPTION
The library consequently supports trailing commas wherever comma-separated items are provided. The shorthand syntax for `elements_are!` and `unordered_elements_are!` did not support this. Thus the following would not compile:

```
verify_that!(vec![1, 2], [eq(1), eq(2),])
verify_that!(vec![1, 2], {eq(1), eq(2),})
```

This change adds support for trailing commas, making the developer experience more consistent within the library and with the Rust language in general.