### PR TITLE
Use star instead of ref in the property matchers (and also the matches_pattern matcher).

### DIFF
--- a/googletest/src/matchers/matches_pattern.rs
+++ b/googletest/src/matchers/matches_pattern.rs
@@ -162,7 +162,7 @@
 /// #     .unwrap();
 /// ```
 ///
-/// If the method returns a reference, precede it with the keyword `ref`:
+/// If the method returns a reference, precede it with a `*`:
 ///
 /// ```
 /// # use googletest::prelude::*;
@@ -177,7 +177,7 @@
 ///
 /// # let my_struct = MyStruct { a_field: "Something to believe in".into() };
 /// verify_that!(my_struct, matches_pattern!(MyStruct {
-///     ref get_a_field_ref(): starts_with("Something"),
+///     *get_a_field_ref(): starts_with("Something"),
 /// }))
 /// #    .unwrap();
 /// ```
@@ -277,11 +277,11 @@ macro_rules! matches_pattern_internal {
 
     (
         [$($struct_name:tt)*],
-        { ref $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
+        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
     ) => {
         $crate::matchers::__internal_unstable_do_not_depend_on_these::is(
             stringify!($($struct_name)*),
-            all!(property!(ref $($struct_name)*.$property_name($($argument),*), $matcher))
+            all!(property!(* $($struct_name)*.$property_name($($argument),*), $matcher))
         )
     };
 
@@ -309,10 +309,10 @@ macro_rules! matches_pattern_internal {
 
     (
         [$($struct_name:tt)*],
-        { ref $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
+        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
     ) => {
         $crate::matches_pattern_internal!(
-            all!(property!(ref $($struct_name)*.$property_name($($argument),*), $matcher)),
+            all!(property!(* $($struct_name)*.$property_name($($argument),*), $matcher)),
             [$($struct_name)*],
             { $($rest)* }
         )
@@ -343,11 +343,11 @@ macro_rules! matches_pattern_internal {
     (
         all!($($processed:tt)*),
         [$($struct_name:tt)*],
-        { ref $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
+        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
     ) => {
         $crate::matchers::__internal_unstable_do_not_depend_on_these::is(stringify!($($struct_name)*), all!(
             $($processed)*,
-            property!(ref $($struct_name)*.$property_name($($argument),*), $matcher)
+            property!(* $($struct_name)*.$property_name($($argument),*), $matcher)
         ))
     };
 
@@ -384,12 +384,12 @@ macro_rules! matches_pattern_internal {
     (
         all!($($processed:tt)*),
         [$($struct_name:tt)*],
-        { ref $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
+        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
     ) => {
         $crate::matches_pattern_internal!(
             all!(
                 $($processed)*,
-                property!(ref $($struct_name)*.$property_name($($argument),*), $matcher)
+                property!(* $($struct_name)*.$property_name($($argument),*), $matcher)
             ),
             [$($struct_name)*],
             { $($rest)* }

--- a/googletest/src/matchers/property_matcher.rs
+++ b/googletest/src/matchers/property_matcher.rs
@@ -44,8 +44,7 @@
 /// failure, it will be invoked a second time, with the assertion failure output
 /// reflecting the *second* invocation.
 ///
-/// If the method returns a *reference*, then it must be preceded by the keyword
-/// `ref`:
+/// If the method returns a *reference*, then it must be preceded by a `*`:
 ///
 /// ```
 /// # use googletest::prelude::*;
@@ -58,7 +57,7 @@
 /// }
 ///
 /// # let value = vec![MyStruct { a_field: 100 }];
-/// verify_that!(value, contains(property!(ref MyStruct.get_a_field(), eq(100))))
+/// verify_that!(value, contains(property!(*MyStruct.get_a_field(), eq(100))))
 /// #    .unwrap();
 /// ```
 ///
@@ -93,7 +92,7 @@
 /// }
 ///
 /// let value = MyStruct { a_string: "A string".into() };
-/// verify_that!(value, property!(ref MyStruct.get_a_string(), eq("A string"))) // Does not compile
+/// verify_that!(value, property!(*MyStruct.get_a_string(), eq("A string"))) // Does not compile
 /// #    .unwrap();
 /// ```
 ///
@@ -120,7 +119,7 @@ macro_rules! property_internal {
             $m)
     }};
 
-    (ref $($t:ident)::+.$method:tt($($argument:tt),* $(,)?), $m:expr) => {{
+    (* $($t:ident)::+.$method:tt($($argument:tt),* $(,)?), $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher;
         property_ref_matcher(
             |o: &$($t)::+| o.$method($($argument),*),

--- a/googletest/tests/matches_pattern_test.rs
+++ b/googletest/tests/matches_pattern_test.rs
@@ -594,7 +594,7 @@ fn includes_struct_name_in_description_with_ref_property() -> Result<()> {
     }
     let actual = AStruct { field: 123 };
 
-    let result = verify_that!(actual, matches_pattern!(AStruct { ref get_field(): eq(234) }));
+    let result = verify_that!(actual, matches_pattern!(AStruct { *get_field(): eq(234) }));
 
     verify_that!(
         result,
@@ -641,10 +641,8 @@ fn includes_struct_name_in_description_with_ref_property_after_field() -> Result
     }
     let actual = AStruct { field: 123 };
 
-    let result = verify_that!(
-        actual,
-        matches_pattern!(AStruct { field: eq(123), ref get_field(): eq(234) })
-    );
+    let result =
+        verify_that!(actual, matches_pattern!(AStruct { field: eq(123), *get_field(): eq(234) }));
 
     verify_that!(
         result,
@@ -781,7 +779,7 @@ fn matches_struct_with_a_method_returning_a_reference() -> Result<()> {
 
     let actual = AStruct { a_field: 123 };
 
-    verify_that!(actual, matches_pattern!(AStruct { ref get_field_ref(): eq(123) }))
+    verify_that!(actual, matches_pattern!(AStruct { *get_field_ref(): eq(123) }))
 }
 
 #[test]
@@ -799,7 +797,7 @@ fn matches_struct_with_a_method_returning_a_reference_with_trailing_comma() -> R
 
     let actual = AStruct { a_field: 123 };
 
-    verify_that!(actual, matches_pattern!(AStruct { ref get_field_ref(): eq(123), }))
+    verify_that!(actual, matches_pattern!(AStruct { *get_field_ref(): eq(123), }))
 }
 
 #[test]
@@ -817,7 +815,7 @@ fn matches_struct_with_a_method_taking_two_parameters_ret_ref() -> Result<()> {
 
     let actual = AStruct { a_field: 1 };
 
-    verify_that!(actual, matches_pattern!(AStruct { ref get_field_ref(2, 3): eq(1) }))
+    verify_that!(actual, matches_pattern!(AStruct { *get_field_ref(2, 3): eq(1) }))
 }
 
 #[test]
@@ -839,7 +837,7 @@ fn matches_struct_with_a_method_returning_reference_taking_enum_value_parameter(
 
     let actual = AStruct { a_field: 1 };
 
-    verify_that!(actual, matches_pattern!(AStruct { ref get_field_ref(AnEnum::AVariant): eq(1) }))
+    verify_that!(actual, matches_pattern!(AStruct { *get_field_ref(AnEnum::AVariant): eq(1) }))
 }
 
 #[test]
@@ -857,7 +855,7 @@ fn matches_struct_with_a_method_taking_two_parameters_with_trailing_comma_ret_re
 
     let actual = AStruct { a_field: 1 };
 
-    verify_that!(actual, matches_pattern!(AStruct { ref get_field_ref(2, 3,): eq(1) }))
+    verify_that!(actual, matches_pattern!(AStruct { *get_field_ref(2, 3,): eq(1) }))
 }
 
 #[test]
@@ -990,7 +988,7 @@ fn matches_struct_with_a_method_returning_reference_followed_by_a_field() -> Res
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { ref get_field_ref(): eq(123), another_field: eq(234) })
+        matches_pattern!(AStruct { *get_field_ref(): eq(123), another_field: eq(234) })
     )
 }
 
@@ -1013,7 +1011,7 @@ fn matches_struct_with_a_method_returning_reference_followed_by_a_field_with_tra
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { ref get_field_ref(): eq(123), another_field: eq(234), })
+        matches_pattern!(AStruct { *get_field_ref(): eq(123), another_field: eq(234), })
     )
 }
 
@@ -1035,7 +1033,7 @@ fn matches_struct_with_a_method_taking_two_parameters_ret_ref_and_field() -> Res
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { ref get_field_ref(2, 3): eq(1), another_field: eq(123) })
+        matches_pattern!(AStruct { *get_field_ref(2, 3): eq(1), another_field: eq(123) })
     )
 }
 
@@ -1061,7 +1059,7 @@ fn matches_struct_with_a_method_taking_enum_value_param_ret_ref_followed_by_fiel
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { ref get_field_ref(AnEnum::AVariant): eq(1), another_field: eq(2) })
+        matches_pattern!(AStruct { *get_field_ref(AnEnum::AVariant): eq(1), another_field: eq(2) })
     )
 }
 
@@ -1084,7 +1082,7 @@ fn matches_struct_with_a_method_taking_two_parameters_with_trailing_comma_ret_re
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { ref get_field_ref(2, 3,): eq(1), another_field: eq(123) })
+        matches_pattern!(AStruct { *get_field_ref(2, 3,): eq(1), another_field: eq(123) })
     )
 }
 
@@ -1217,7 +1215,7 @@ fn matches_struct_with_a_field_followed_by_a_method_returning_reference() -> Res
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { another_field: eq(234), ref get_field_ref(): eq(123) })
+        matches_pattern!(AStruct { another_field: eq(234), *get_field_ref(): eq(123) })
     )
 }
 
@@ -1240,7 +1238,7 @@ fn matches_struct_with_a_field_followed_by_a_method_returning_ref_and_trailing_c
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { another_field: eq(234), ref get_field_ref(): eq(123), })
+        matches_pattern!(AStruct { another_field: eq(234), *get_field_ref(): eq(123), })
     )
 }
 
@@ -1262,7 +1260,7 @@ fn matches_struct_with_a_field_followed_by_a_method_with_params_ret_ref() -> Res
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { another_field: eq(234), ref get_field_ref(2, 3): eq(123) })
+        matches_pattern!(AStruct { another_field: eq(234), *get_field_ref(2, 3): eq(123) })
     )
 }
 
@@ -1288,7 +1286,7 @@ fn matches_struct_with_field_followed_by_method_taking_enum_value_param_ret_ref(
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { another_field: eq(2), ref get_field_ref(AnEnum::AVariant): eq(1) })
+        matches_pattern!(AStruct { another_field: eq(2), *get_field_ref(AnEnum::AVariant): eq(1) })
     )
 }
 
@@ -1311,7 +1309,7 @@ fn matches_struct_with_a_field_followed_by_a_method_with_params_and_trailing_com
 
     verify_that!(
         actual,
-        matches_pattern!(AStruct { another_field: eq(234), ref get_field_ref(2, 3,): eq(123) })
+        matches_pattern!(AStruct { another_field: eq(234), *get_field_ref(2, 3,): eq(123) })
     )
 }
 
@@ -1479,7 +1477,7 @@ fn matches_struct_with_a_field_followed_by_a_method_ret_ref_followed_by_a_field(
         actual,
         matches_pattern!(AStruct {
             another_field: eq(234),
-            ref get_field_ref(): eq(123),
+            *get_field_ref(): eq(123),
             a_third_field: eq(345)
         })
     )
@@ -1507,7 +1505,7 @@ fn matches_struct_with_a_field_followed_by_a_method_ret_ref_followed_by_a_field_
         actual,
         matches_pattern!(AStruct {
             another_field: eq(234),
-            ref get_field_ref(): eq(123),
+            *get_field_ref(): eq(123),
             a_third_field: eq(345),
         })
     )
@@ -1535,7 +1533,7 @@ fn matches_struct_with_a_field_followed_by_a_method_with_params_ret_ref_followed
         actual,
         matches_pattern!(AStruct {
             another_field: eq(234),
-            ref get_field_ref(2, 3): eq(123),
+            *get_field_ref(2, 3): eq(123),
             a_third_field: eq(345),
         })
     )
@@ -1567,7 +1565,7 @@ fn matches_struct_with_field_followed_by_method_taking_enum_value_param_ret_ref_
         actual,
         matches_pattern!(AStruct {
             another_field: eq(2),
-            ref get_field_ref(AnEnum::AVariant): eq(1),
+            *get_field_ref(AnEnum::AVariant): eq(1),
             a_third_field: eq(3),
         })
     )
@@ -1595,7 +1593,7 @@ fn matches_struct_with_a_field_followed_by_a_method_with_params_trailing_comma_r
         actual,
         matches_pattern!(AStruct {
             another_field: eq(234),
-            ref get_field_ref(2, 3,): eq(123),
+            *get_field_ref(2, 3,): eq(123),
             a_third_field: eq(345),
         })
     )

--- a/googletest/tests/property_matcher_test.rs
+++ b/googletest/tests/property_matcher_test.rs
@@ -67,7 +67,7 @@ fn matches_struct_with_matching_property_with_parameters_with_trailing_comma() -
 #[test]
 fn matches_struct_with_matching_property_ref() -> Result<()> {
     let value = SomeStruct { a_property: 10 };
-    verify_that!(value, property!(ref SomeStruct.get_property_ref(), eq(10)))
+    verify_that!(value, property!(*SomeStruct.get_property_ref(), eq(10)))
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn matches_struct_with_matching_string_reference_property() -> Result<()> {
         }
     }
     let value = StructWithString { property: "Something".into() };
-    verify_that!(value, property!(ref StructWithString.get_property_ref(), eq("Something")))
+    verify_that!(value, property!(*StructWithString.get_property_ref(), eq("Something")))
 }
 
 #[test]
@@ -97,19 +97,19 @@ fn matches_struct_with_matching_slice_property() -> Result<()> {
         }
     }
     let value = StructWithVec { property: vec![1, 2, 3] };
-    verify_that!(value, property!(ref StructWithVec.get_property_ref(), eq([1, 2, 3])))
+    verify_that!(value, property!(*StructWithVec.get_property_ref(), eq([1, 2, 3])))
 }
 
 #[test]
 fn matches_struct_with_matching_property_ref_with_parameters() -> Result<()> {
     let value = SomeStruct { a_property: 10 };
-    verify_that!(value, property!(ref SomeStruct.get_property_ref_with_params(2, 3), eq(10)))
+    verify_that!(value, property!(*SomeStruct.get_property_ref_with_params(2, 3), eq(10)))
 }
 
 #[test]
 fn matches_struct_with_matching_property_ref_with_parameters_and_trailing_comma() -> Result<()> {
     let value = SomeStruct { a_property: 10 };
-    verify_that!(value, property!(ref SomeStruct.get_property_ref_with_params(2, 3,), eq(10)))
+    verify_that!(value, property!(*SomeStruct.get_property_ref_with_params(2, 3,), eq(10)))
 }
 
 #[test]
@@ -155,7 +155,7 @@ fn explains_mismatch_referencing_explanation_of_inner_matcher() -> Result<()> {
 #[test]
 fn describes_itself_in_matching_case_for_ref() -> Result<()> {
     verify_that!(
-        property!(ref SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::Match),
+        property!(*SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::Match),
         eq("has property `get_property_ref()`, which is equal to 1")
     )
 }
@@ -163,7 +163,7 @@ fn describes_itself_in_matching_case_for_ref() -> Result<()> {
 #[test]
 fn describes_itself_in_not_matching_case_for_ref() -> Result<()> {
     verify_that!(
-        property!(ref SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::NoMatch),
+        property!(*SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::NoMatch),
         eq("has property `get_property_ref()`, which isn't equal to 1")
     )
 }
@@ -178,7 +178,7 @@ fn explains_mismatch_referencing_explanation_of_inner_matcher_for_ref() -> Resul
     }
     let value = SomeStruct { a_property: 2 };
     let result =
-        verify_that!(value, property!(ref SomeStruct.get_a_collection_ref(), container_eq([1])));
+        verify_that!(value, property!(*SomeStruct.get_a_collection_ref(), container_eq([1])));
 
     verify_that!(
         result,


### PR DESCRIPTION
The keyword `ref` normally implies taking the object by reference and applied on non-reference identifier. However, in the `matchers_pattern` matcher, it was used to tag a method as returning references, with almost  a meaning of dereference.

For instance:

```
struct AStruct {
  a_field: String
}
  
let a_struct = AStruct{a_field: "a_string".into()};
  
match a_struct {
  AStruct { a_field: ref a_string } => println!("{a_string}")
}
```

can be understood as: "apply the pattern and take `a_struct.a_field` *by reference*".

Before this change:

```
#[derive(Debug)]
struct AStruct {
  a_field: u32,
}

impl AStruct {
  fn a_field(&self) -> &u32 {&self.a_field}
}

let actual = AStruct { a_field: 123 };
verify_that!(
  actual,
  matches_pattern!(AStruct {
    ref a_field(): eq(123),
  })
)
```

can be understood as: "apply the pattern, run `actual.a_field()`, *dereference* the result and check the matcher".

To express the meaning of dereference, it is thus more appropriate to use "*".

```
#[derive(Debug)]
struct AStruct {
  a_field: u32,
}

impl AStruct {
  fn a_field(&self) -> &u32 {&self.a_field}
}

let actual = AStruct { a_field: 123 };
verify_that!(
  actual,
  matches_pattern!(AStruct {
    *a_field(): eq(123),
  })
)
```