### PR TITLE
Pin the dependency on async-executor in the integration-tests crate to version 1.5.1.

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1"
 indoc = "2"
 rstest = "0.13.0"
 tokio = { version = "=1.29.1", features = ["time", "macros", "rt"] }
+async-executor = { version = "=1.5.1" }
 
 [[bin]]
 name = "integration_tests"


### PR DESCRIPTION
Normally this is a transitive dependency of rstest with no direct dependency from integration-tests itself. But one of intermediate dependencies did not pin it, so it was silently upgraded to 1.5.4, which raised the MSRV from 1.59.0 to 1.61.0. Thus the integration tests could no longer run on our MSRV of 1.59.0.

This change pins the transitive dependency so that the integration tests compile again under our MSRV.