### PR TITLE
Update MSRV from 1.59 to 1.66

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     name: test (no default features) / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable, 1.59]
+        toolchain: [stable, 1.66]
     steps:
       - uses: actions/checkout@v4
       - name: Install ${{ matrix.toolchain }}
@@ -80,7 +80,7 @@ jobs:
     name: integration-test / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable, 1.59.0, nightly, beta]
+        toolchain: [stable, 1.66.0, nightly, beta]
     steps:
       - uses: actions/checkout@v4
       - name: Install ${{ matrix.toolchain }}

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ This library brings the rich assertion types of Google's C++ testing library
  * A new set of assertion macros offering similar functionality to those of
    [GoogleTest](https://google.github.io/googletest/primer.html#assertions).
 
-**The minimum supported Rust version is 1.59**. We recommend using at least
-version 1.66 for the best developer experience.
+**The minimum supported Rust version is 1.66**.
 
 > :warning: The API is not fully stable and may still be changed until we
 > publish version 1.0.

--- a/googletest/Cargo.toml
+++ b/googletest/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/google/googletest-rust"
 readme = "../README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.66.0"
 authors = [
   "Bradford Hovinen <hovinen@google.com>",
   "Bastien Jacot-Guillarmod <bjacotg@google.com>",
@@ -33,9 +33,9 @@ authors = [
 [dependencies]
 googletest_macro = { path = "../googletest_macro", version = "0.10.0" }
 anyhow = { version = "1", optional = true }
-num-traits = "0.2.15"
+num-traits = "0.2.17"
 proptest = { version = "1.2.0", optional = true }
-regex = "1.6.0"
+regex = "1.7.3"
 rustversion = "1.0.14"
 
 [dev-dependencies]

--- a/googletest_macro/Cargo.toml
+++ b/googletest_macro/Cargo.toml
@@ -26,8 +26,8 @@ authors = [
 ]
 
 [dependencies]
-quote = "1.0.21"
-syn = {version = "2.0.10", features = ["full"]}
+quote = "1.0.33"
+syn = {version = "2.0.39", features = ["full"]}
 
 [lib]
 name = "googletest_macro"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -19,7 +19,7 @@ description = "Integration tests for GoogleTest Rust"
 repository = "https://github.com/google/googletest-rust"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.66.0"
 authors = [
   "Bradford Hovinen <hovinen@google.com>",
   "Bastien Jacot-Guillarmod <bjacotg@google.com>",
@@ -31,9 +31,8 @@ authors = [
 googletest = { path = "../googletest", version = "0.10.0", features = ["anyhow"] }
 anyhow = "1"
 indoc = "2"
-rstest = "0.13.0"
-tokio = { version = "=1.29.1", features = ["time", "macros", "rt"] }
-async-executor = { version = "=1.5.1" }
+rstest = "0.18"
+tokio = { version = "1.34", features = ["time", "macros", "rt"] }
 
 [[bin]]
 name = "integration_tests"


### PR DESCRIPTION
This PR change the MSRV from 1.59 to 1.66.

The main dependent requiring 1.59 MSRV has updated their toolchain, so we are free to update in order to keep up with our dependencies.

This PR was generated with:
* Running `cargo upgrade` from [cargo-edit](https://crates.io/crates/cargo-edit)
* Running `cargo msrv` from [cargo-msrv](https://crates.io/crates/cargo-msrv)
  * This resulted in 1.65

However, integrations tests failed at 1.65 probably due to a regression between 1.59 and 1.65 (probably between 1.62 and 1.63). This was probably fixed in [this PR](https://github.com/rust-lang/rust/commit/13f47f608e8e9fcdd60f64688e12f5f4c2f7c317) and all versions between 1.66 and 1.74 succeeded.



