### PR TITLE
Add an extra whitespace between subsequent non-fatal failure messages.

### DIFF
--- a/googletest/src/internal/test_outcome.rs
+++ b/googletest/src/internal/test_outcome.rs
@@ -174,7 +174,7 @@ impl TestAssertionFailure {
 
     pub(crate) fn log(&self) {
         TestOutcome::fail_current_test();
-        print!("{}", self);
+        println!("{}", self);
     }
 }
 

--- a/integration_tests/src/integration_tests.rs
+++ b/integration_tests/src/integration_tests.rs
@@ -137,13 +137,18 @@ mod tests {
     }
 
     #[test]
-    fn should_output_second_failure_message_on_second_assertion_failure_with_expect_that()
-    -> Result<()> {
+    fn should_output_both_failure_messages_when_two_expect_that_assertions_fail() -> Result<()> {
         let output = run_external_process_in_tests_directory("two_expect_that_failures")?;
 
         verify_that!(
             output,
             contains_regex(indoc! {"
+                Value of: value
+                Expected: is equal to 3
+                Actual: 2,
+                  which isn't equal to 3
+                  at .*integration_tests/src/two_expect_that_failures.rs:[0-9]+:9
+
                 Value of: value
                 Expected: is equal to 4
                 Actual: 2,


### PR DESCRIPTION
Previously, subsequent non-fatal failure messages had no intervening whitespace, leading them to be visually hard to separate:

    Value of: value
    Expected: is equal to 3
    Actual: 2,
      which isn't equal to 3
      at .*integration_tests/src/two_expect_that_failures.rs:[0-9]+:9
    Value of: value
    Expected: is equal to 4
    Actual: 2,
      which isn't equal to 4
      at .*integration_tests/src/two_expect_that_failures.rs:[0-9]+:9

This modifies the `TestAssertionFailure::log` method to output an extra newline after a non-fatal failure message, making the individual failures easier to read:

    Value of: value
    Expected: is equal to 3
    Actual: 2,
      which isn't equal to 3
      at .*integration_tests/src/two_expect_that_failures.rs:[0-9]+:9

    Value of: value
    Expected: is equal to 4
    Actual: 2,
      which isn't equal to 4
      at .*integration_tests/src/two_expect_that_failures.rs:[0-9]+:9