### PR TITLE
Set the resolver in the top-level Cargo.toml that of to the 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 [workspace]
+resolver = "2"
 members = [
   "googletest_macro",
   "googletest",


### PR DESCRIPTION
Previously, compiling the library on a recent Rust version gave a bunch of warnings:

    warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
    note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
    note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest

This change eliminates those warnings by setting the resolver to version 2.