### PR TITLE
Rewrite the mechanism for rendering descriptions and match explanations

### DIFF
--- a/googletest/crate_docs.md
+++ b/googletest/crate_docs.md
@@ -209,7 +209,7 @@ a struct holding the matcher's data and have it implement the trait
 [`Matcher`]:
 
 ```no_run
-use googletest::matcher::{Matcher, MatcherResult};
+use googletest::{description::Description, matcher::{Matcher, MatcherResult}};
 use std::fmt::Debug;
 
 struct MyEqMatcher<T> {
@@ -227,13 +227,13 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
-                format!("is equal to {:?} the way I define it", self.expected)
+                format!("is equal to {:?} the way I define it", self.expected).into()
             }
             MatcherResult::NoMatch => {
-                format!("isn't equal to {:?} the way I define it", self.expected)
+                format!("isn't equal to {:?} the way I define it", self.expected).into()
             }
         }
     }
@@ -243,7 +243,7 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
  It is recommended to expose a function which constructs the matcher:
 
  ```no_run
- # use googletest::matcher::{Matcher, MatcherResult};
+ # use googletest::{description::Description, matcher::{Matcher, MatcherResult}};
  # use std::fmt::Debug;
  #
  # struct MyEqMatcher<T> {
@@ -261,13 +261,13 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
  #        }
  #    }
  #
- #    fn describe(&self, matcher_result: MatcherResult) -> String {
+ #    fn describe(&self, matcher_result: MatcherResult) -> Description {
  #        match matcher_result {
  #            MatcherResult::Match => {
- #                format!("is equal to {:?} the way I define it", self.expected)
+ #                format!("is equal to {:?} the way I define it", self.expected).into()
  #            }
  #            MatcherResult::NoMatch => {
- #                format!("isn't equal to {:?} the way I define it", self.expected)
+ #                format!("isn't equal to {:?} the way I define it", self.expected).into()
  #            }
  #        }
  #    }
@@ -282,7 +282,7 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
 
 ```
 # use googletest::prelude::*;
-# use googletest::matcher::{Matcher, MatcherResult};
+# use googletest::{description::Description, matcher::{Matcher, MatcherResult}};
 # use std::fmt::Debug;
 #
 # struct MyEqMatcher<T> {
@@ -300,13 +300,13 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
 #        }
 #    }
 #
-#    fn describe(&self, matcher_result: MatcherResult) -> String {
+#    fn describe(&self, matcher_result: MatcherResult) -> Description {
 #        match matcher_result {
 #            MatcherResult::Match => {
-#                format!("is equal to {:?} the way I define it", self.expected)
+#                format!("is equal to {:?} the way I define it", self.expected).into()
 #            }
 #            MatcherResult::NoMatch => {
-#                format!("isn't equal to {:?} the way I define it", self.expected)
+#                format!("isn't equal to {:?} the way I define it", self.expected).into()
 #            }
 #        }
 #    }

--- a/googletest/src/description.rs
+++ b/googletest/src/description.rs
@@ -41,22 +41,24 @@ use std::fmt::{Display, Formatter, Result};
 /// They can also be indented, enumerated and or
 /// bullet listed if [`Description::indent`], [`Description::enumerate`], or
 /// respectively [`Description::bullet_list`] has been called.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Description {
     elements: Vec<String>,
     indent_mode: IndentMode,
     list_style: ListStyle,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 enum IndentMode {
+    #[default]
     NoIndent,
     EveryLine,
     AllExceptFirstLine,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 enum ListStyle {
+    #[default]
     NoList,
     Bullet,
     Enumerate,
@@ -229,6 +231,9 @@ impl Display for Description {
                 writeln!(f)?;
                 write!(f, "{:other_line_indent$}{line}", "")?;
             }
+            if element.ends_with("\n") {
+                writeln!(f)?;
+            }
             first_line_indent = first_line_of_element_indent;
         }
         Ok(())
@@ -240,11 +245,22 @@ impl FromIterator<String> for Description {
     where
         T: IntoIterator<Item = String>,
     {
-        Self {
-            elements: iter.into_iter().collect(),
-            indent_mode: IndentMode::NoIndent,
-            list_style: ListStyle::NoList,
-        }
+        Self { elements: iter.into_iter().collect(), ..Default::default() }
+    }
+}
+
+impl FromIterator<Description> for Description {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Description>,
+    {
+        Self { elements: iter.into_iter().map(|s| format!("{s}")).collect(), ..Default::default() }
+    }
+}
+
+impl<T: Into<String>> From<T> for Description {
+    fn from(value: T) -> Self {
+        Self { elements: vec![value.into()], ..Default::default() }
     }
 }
 

--- a/googletest/src/description.rs
+++ b/googletest/src/description.rs
@@ -83,7 +83,7 @@ impl Description {
     ///
     /// ```
     /// # use googletest::prelude::*;
-    /// # use googletest::matcher_support::description::Description;
+    /// # use googletest::description::Description;
     /// let description = std::iter::once("A B C\nD E F".to_string()).collect::<Description>();
     /// verify_that!(description.indent(), displays_as(eq("  A B C\n  D E F")))
     /// # .unwrap();
@@ -103,7 +103,7 @@ impl Description {
     ///
     /// ```
     /// # use googletest::prelude::*;
-    /// # use googletest::matcher_support::description::Description;
+    /// # use googletest::description::Description;
     /// let description = std::iter::once("A B C\nD E F".to_string()).collect::<Description>();
     /// verify_that!(description.indent_except_first_line(), displays_as(eq("A B C\n  D E F")))
     /// # .unwrap();
@@ -123,7 +123,7 @@ impl Description {
     ///
     /// ```
     /// # use googletest::prelude::*;
-    /// # use googletest::matcher_support::description::Description;
+    /// # use googletest::description::Description;
     /// let description = std::iter::once("A B C\nD E F".to_string()).collect::<Description>();
     /// verify_that!(description.bullet_list(), displays_as(eq("* A B C\n  D E F")))
     /// # .unwrap();
@@ -143,7 +143,7 @@ impl Description {
     ///
     /// ```
     /// # use googletest::prelude::*;
-    /// # use googletest::matcher_support::description::Description;
+    /// # use googletest::description::Description;
     /// let description = std::iter::once("A B C\nD E F".to_string()).collect::<Description>();
     /// verify_that!(description.enumerate(), displays_as(eq("0. A B C\n   D E F")))
     /// # .unwrap();

--- a/googletest/src/internal/description_renderer.rs
+++ b/googletest/src/internal/description_renderer.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Remove this once this module is actually used.
-#![cfg(test)]
-
 use std::{
     borrow::Cow,
     fmt::{Result, Write},
@@ -132,6 +129,18 @@ impl List {
         self.render_with_prefix(f, indentation, "".into())
     }
 
+    /// Append a new [`Block`] containing `literal`.
+    ///
+    /// The input `literal` is split into lines so that each line will be indented correctly.
+    pub(crate) fn push_literal(&mut self, literal: Cow<'static, str>) {
+        self.0.push(literal.into());
+    }
+
+    /// Append a new [`Block`] containing `inner` as a nested [`List`].
+    pub(crate) fn push_nested(&mut self, inner: List) {
+        self.0.push(Block::Nested(inner));
+    }
+
     /// Render each [`Block`] of this instance preceded with a bullet "* ".
     pub(crate) fn bullet_list(self) -> Self {
         Self(self.0, Decoration::Bullet)
@@ -140,6 +149,16 @@ impl List {
     /// Render each [`Block`] of this instance preceded with its 0-based index.
     pub(crate) fn enumerate(self) -> Self {
         Self(self.0, Decoration::Enumerate)
+    }
+
+    /// Return the number of [`Block`] in this instance.
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Return `true` if there are no [`Block`] in this instance, `false` otherwise.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     fn render_with_prefix(

--- a/googletest/src/internal/description_renderer.rs
+++ b/googletest/src/internal/description_renderer.rs
@@ -226,12 +226,12 @@ impl FromIterator<Block> for List {
     }
 }
 
-impl FromIterator<String> for List {
+impl<ElementT: Into<Cow<'static, str>>> FromIterator<ElementT> for List {
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = String>,
+        T: IntoIterator<Item = ElementT>,
     {
-        Self(iter.into_iter().map(|b| b.into()).collect(), Decoration::None)
+        Self(iter.into_iter().map(|b| b.into().into()).collect(), Decoration::None)
     }
 }
 

--- a/googletest/src/internal/description_renderer.rs
+++ b/googletest/src/internal/description_renderer.rs
@@ -1,0 +1,590 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: Remove this once this module is actually used.
+#![cfg(test)]
+
+use std::{
+    borrow::Cow,
+    fmt::{Result, Write},
+};
+
+/// Number of space used to indent lines when no alignement is required.
+pub(crate) const INDENTATION_SIZE: usize = 2;
+
+/// A string representing one line of a description or match explanation.
+#[derive(Debug)]
+struct Fragment(Cow<'static, str>);
+
+impl Fragment {
+    fn render(&self, f: &mut dyn Write) -> Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A sequence of [`Fragment`] or a nested [`List`].
+///
+/// This may be rendered with a prefix specified by the [`Decoration`] of the containing [`List`].
+/// In this case, all lines are indented to align with the first character of the first line of the
+/// block.
+#[derive(Debug)]
+enum Block {
+    /// A block of text.
+    ///
+    /// Each constituent [`Fragment`] contains one line of text. The lines are indented
+    /// uniformly to the current indentation of this block when rendered.
+    Literal(Vec<Fragment>),
+
+    /// A nested [`List`].
+    ///
+    /// The [`List`] is rendered recursively at the next level of indentation.
+    Nested(List),
+}
+
+impl Block {
+    fn nested(inner: List) -> Self {
+        Self::Nested(inner)
+    }
+
+    fn render(&self, f: &mut dyn Write, indentation: usize, prefix: Cow<'static, str>) -> Result {
+        match self {
+            Self::Literal(fragments) => {
+                if fragments.is_empty() {
+                    return Ok(());
+                }
+
+                write!(f, "{:indentation$}{prefix}", "")?;
+                fragments[0].render(f)?;
+                let block_indentation = indentation + prefix.as_ref().len();
+                for fragment in &fragments[1..] {
+                    writeln!(f)?;
+                    write!(f, "{:block_indentation$}", "")?;
+                    fragment.render(f)?;
+                }
+                Ok(())
+            }
+            Self::Nested(inner) => inner.render_with_prefix(
+                f,
+                indentation + INDENTATION_SIZE.saturating_sub(prefix.len()),
+                prefix,
+            ),
+        }
+    }
+}
+
+impl From<String> for Block {
+    fn from(value: String) -> Self {
+        Block::Literal(value.lines().map(|v| Fragment(v.to_string().into())).collect())
+    }
+}
+
+impl From<&'static str> for Block {
+    fn from(value: &'static str) -> Self {
+        Block::Literal(value.lines().map(|v| Fragment(v.into())).collect())
+    }
+}
+
+impl From<Cow<'static, str>> for Block {
+    fn from(value: Cow<'static, str>) -> Self {
+        match value {
+            Cow::Borrowed(value) => value.into(),
+            Cow::Owned(value) => value.into(),
+        }
+    }
+}
+
+/// A list of [`Block`] possibly rendered with a [`Decoration`].
+///
+/// This is the top-level renderable component, corresponding to the description or match
+/// explanation of a single matcher.
+///
+/// The constituent [`Block`] of a `List` can be decorated with either bullets (`* `) or enumeration
+/// (`0. `, `1. `, ...). This is controlled via the methods [`List::bullet_list`] and
+/// [`List::enumerate`]. By default, there is no decoration.
+///
+/// A `List` can be constructed as follows:
+///
+///   * [`Default::default()`] constructs an empty `List`.
+///   * [`Iterator::collect()`] on an [`Iterator`] of [`Block`].
+///   * [`Iterator::collect()`] on an [`Iterator`] of `String`, which produces a [`Block::Literal`]
+///     for each `String`.
+///   * [`Iterator::collect()`] on an [`Iterator`] of `List`, which produces a [`Block::Nested`] for
+///     each `List`.
+#[derive(Debug, Default)]
+pub(crate) struct List(Vec<Block>, Decoration);
+
+impl List {
+    /// Render this instance using the formatter `f`.
+    ///
+    /// Indent each line of output by `indentation` spaces.
+    pub(crate) fn render(&self, f: &mut dyn Write, indentation: usize) -> Result {
+        self.render_with_prefix(f, indentation, "".into())
+    }
+
+    /// Render each [`Block`] of this instance preceded with a bullet "* ".
+    pub(crate) fn bullet_list(self) -> Self {
+        Self(self.0, Decoration::Bullet)
+    }
+
+    /// Render each [`Block`] of this instance preceded with its 0-based index.
+    pub(crate) fn enumerate(self) -> Self {
+        Self(self.0, Decoration::Enumerate)
+    }
+
+    fn render_with_prefix(
+        &self,
+        f: &mut dyn Write,
+        indentation: usize,
+        prefix: Cow<'static, str>,
+    ) -> Result {
+        if self.0.is_empty() {
+            return Ok(());
+        }
+
+        let enumeration_padding = self.enumeration_padding();
+
+        self.0[0].render(
+            f,
+            indentation,
+            self.full_prefix(0, enumeration_padding, &prefix).into(),
+        )?;
+        for (index, block) in self.0[1..].iter().enumerate() {
+            writeln!(f)?;
+            block.render(
+                f,
+                indentation + prefix.len(),
+                self.prefix(index + 1, enumeration_padding),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn full_prefix(&self, index: usize, enumeration_padding: usize, prior_prefix: &str) -> String {
+        format!("{prior_prefix}{}", self.prefix(index, enumeration_padding))
+    }
+
+    fn prefix(&self, index: usize, enumeration_padding: usize) -> Cow<'static, str> {
+        match self.1 {
+            Decoration::None => "".into(),
+            Decoration::Bullet => "* ".into(),
+            Decoration::Enumerate => format!("{:>enumeration_padding$}. ", index).into(),
+        }
+    }
+
+    fn enumeration_padding(&self) -> usize {
+        match self.1 {
+            Decoration::None => 0,
+            Decoration::Bullet => 0,
+            Decoration::Enumerate => {
+                if self.0.len() > 1 {
+                    ((self.0.len() - 1) as f64).log10().floor() as usize + 1
+                } else {
+                    // Avoid negative logarithm when there is only 0 or 1 element.
+                    1
+                }
+            }
+        }
+    }
+}
+
+impl FromIterator<Block> for List {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Block>,
+    {
+        Self(iter.into_iter().collect(), Decoration::None)
+    }
+}
+
+impl FromIterator<String> for List {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = String>,
+    {
+        Self(iter.into_iter().map(|b| b.into()).collect(), Decoration::None)
+    }
+}
+
+impl FromIterator<List> for List {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = List>,
+    {
+        Self(iter.into_iter().map(Block::nested).collect(), Decoration::None)
+    }
+}
+
+/// The decoration which appears on [`Block`] of a [`List`] when rendered.
+#[derive(Debug, Default)]
+enum Decoration {
+    /// No decoration on each [`Block`]. The default.
+    #[default]
+    None,
+
+    /// Each [`Block`] is preceded by a bullet (`* `).
+    Bullet,
+
+    /// Each [`Block`] is preceded by its index in the [`List`] (`0. `, `1. `, ...).
+    Enumerate,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Block, Fragment, List};
+    use crate::prelude::*;
+    use indoc::indoc;
+
+    #[test]
+    fn renders_fragment() -> Result<()> {
+        let fragment = Fragment("A fragment".into());
+        let mut result = String::new();
+
+        fragment.render(&mut result)?;
+
+        verify_that!(result, eq("A fragment"))
+    }
+
+    #[test]
+    fn renders_empty_block() -> Result<()> {
+        let block = Block::Literal(vec![]);
+        let mut result = String::new();
+
+        block.render(&mut result, 0, "".into())?;
+
+        verify_that!(result, eq(""))
+    }
+
+    #[test]
+    fn renders_block_with_one_fragment() -> Result<()> {
+        let block: Block = "A fragment".into();
+        let mut result = String::new();
+
+        block.render(&mut result, 0, "".into())?;
+
+        verify_that!(result, eq("A fragment"))
+    }
+
+    #[test]
+    fn renders_block_with_two_fragments() -> Result<()> {
+        let block: Block = "A fragment\nAnother fragment".into();
+        let mut result = String::new();
+
+        block.render(&mut result, 0, "".into())?;
+
+        verify_that!(result, eq("A fragment\nAnother fragment"))
+    }
+
+    #[test]
+    fn renders_indented_block() -> Result<()> {
+        let block: Block = "A fragment\nAnother fragment".into();
+        let mut result = String::new();
+
+        block.render(&mut result, 2, "".into())?;
+
+        verify_that!(result, eq("  A fragment\n  Another fragment"))
+    }
+
+    #[test]
+    fn renders_block_with_prefix() -> Result<()> {
+        let block: Block = "A fragment\nAnother fragment".into();
+        let mut result = String::new();
+
+        block.render(&mut result, 0, "* ".into())?;
+
+        verify_that!(result, eq("* A fragment\n  Another fragment"))
+    }
+
+    #[test]
+    fn renders_indented_block_with_prefix() -> Result<()> {
+        let block: Block = "A fragment\nAnother fragment".into();
+        let mut result = String::new();
+
+        block.render(&mut result, 2, "* ".into())?;
+
+        verify_that!(result, eq("  * A fragment\n    Another fragment"))
+    }
+
+    #[test]
+    fn renders_empty_list() -> Result<()> {
+        let list = list(vec![]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq(""))
+    }
+
+    #[test]
+    fn renders_plain_list_with_one_block() -> Result<()> {
+        let list = list(vec!["A fragment".into()]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("A fragment"))
+    }
+
+    #[test]
+    fn renders_plain_list_with_two_blocks() -> Result<()> {
+        let list = list(vec!["A fragment".into(), "A fragment in a second block".into()]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("A fragment\nA fragment in a second block"))
+    }
+
+    #[test]
+    fn renders_plain_list_with_one_block_with_two_fragments() -> Result<()> {
+        let list = list(vec!["A fragment\nA second fragment".into()]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("A fragment\nA second fragment"))
+    }
+
+    #[test]
+    fn renders_nested_plain_list_with_one_block() -> Result<()> {
+        let list = list(vec![Block::nested(list(vec!["A fragment".into()]))]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("  A fragment"))
+    }
+
+    #[test]
+    fn renders_nested_plain_list_with_two_blocks() -> Result<()> {
+        let list = list(vec![Block::nested(list(vec![
+            "A fragment".into(),
+            "A fragment in a second block".into(),
+        ]))]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("  A fragment\n  A fragment in a second block"))
+    }
+
+    #[test]
+    fn renders_nested_plain_list_with_one_block_with_two_fragments() -> Result<()> {
+        let list = list(vec![Block::nested(list(vec!["A fragment\nA second fragment".into()]))]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("  A fragment\n  A second fragment"))
+    }
+
+    #[test]
+    fn renders_bulleted_list_with_one_block() -> Result<()> {
+        let list = list(vec!["A fragment".into()]).bullet_list();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("* A fragment"))
+    }
+
+    #[test]
+    fn renders_bulleted_list_with_two_blocks() -> Result<()> {
+        let list =
+            list(vec!["A fragment".into(), "A fragment in a second block".into()]).bullet_list();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("* A fragment\n* A fragment in a second block"))
+    }
+
+    #[test]
+    fn renders_bulleted_list_with_one_block_with_two_fragments() -> Result<()> {
+        let list = list(vec!["A fragment\nA second fragment".into()]).bullet_list();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("* A fragment\n  A second fragment"))
+    }
+
+    #[test]
+    fn renders_nested_bulleted_list_with_one_block() -> Result<()> {
+        let list = list(vec![Block::nested(list(vec!["A fragment".into()]).bullet_list())]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("  * A fragment"))
+    }
+
+    #[test]
+    fn renders_nested_bulleted_list_with_two_blocks() -> Result<()> {
+        let list = list(vec![Block::nested(
+            list(vec!["A fragment".into(), "A fragment in a second block".into()]).bullet_list(),
+        )]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("  * A fragment\n  * A fragment in a second block"))
+    }
+
+    #[test]
+    fn renders_nested_bulleted_list_with_one_block_with_two_fragments() -> Result<()> {
+        let list = list(vec![Block::nested(
+            list(vec!["A fragment\nA second fragment".into()]).bullet_list(),
+        )]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("  * A fragment\n    A second fragment"))
+    }
+
+    #[test]
+    fn renders_enumerated_list_with_one_block() -> Result<()> {
+        let list = list(vec!["A fragment".into()]).enumerate();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("0. A fragment"))
+    }
+
+    #[test]
+    fn renders_enumerated_list_with_two_blocks() -> Result<()> {
+        let list =
+            list(vec!["A fragment".into(), "A fragment in a second block".into()]).enumerate();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("0. A fragment\n1. A fragment in a second block"))
+    }
+
+    #[test]
+    fn renders_enumerated_list_with_one_block_with_two_fragments() -> Result<()> {
+        let list = list(vec!["A fragment\nA second fragment".into()]).enumerate();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("0. A fragment\n   A second fragment"))
+    }
+
+    #[test]
+    fn aligns_renders_enumerated_list_with_more_than_ten_blocks() -> Result<()> {
+        let list =
+            (0..11).map(|i| Block::from(format!("Fragment {i}"))).collect::<List>().enumerate();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(
+            result,
+            eq(indoc! {"
+                 0. Fragment 0
+                 1. Fragment 1
+                 2. Fragment 2
+                 3. Fragment 3
+                 4. Fragment 4
+                 5. Fragment 5
+                 6. Fragment 6
+                 7. Fragment 7
+                 8. Fragment 8
+                 9. Fragment 9
+                10. Fragment 10"})
+        )
+    }
+
+    #[test]
+    fn renders_fragment_plus_nested_plain_list_with_one_block() -> Result<()> {
+        let list =
+            list(vec!["A fragment".into(), Block::nested(list(vec!["Another fragment".into()]))]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("A fragment\n  Another fragment"))
+    }
+
+    #[test]
+    fn renders_double_nested_plain_list_with_one_block() -> Result<()> {
+        let list =
+            list(vec![Block::nested(list(vec![Block::nested(list(vec!["A fragment".into()]))]))]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("    A fragment"))
+    }
+
+    #[test]
+    fn renders_headers_plus_double_nested_plain_list() -> Result<()> {
+        let list = list(vec![
+            "First header".into(),
+            Block::nested(list(vec![
+                "Second header".into(),
+                Block::nested(list(vec!["A fragment".into()])),
+            ])),
+        ]);
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("First header\n  Second header\n    A fragment"))
+    }
+
+    #[test]
+    fn renders_double_nested_bulleted_list() -> Result<()> {
+        let list =
+            list(vec![Block::nested(list(vec!["A fragment".into()]).bullet_list())]).bullet_list();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("* * A fragment"))
+    }
+
+    #[test]
+    fn renders_nested_enumeration_with_two_blocks_inside_bulleted_list() -> Result<()> {
+        let list =
+            list(vec![Block::nested(list(vec!["Block 1".into(), "Block 2".into()]).enumerate())])
+                .bullet_list();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("* 0. Block 1\n  1. Block 2"))
+    }
+
+    #[test]
+    fn renders_nested_enumeration_with_block_with_two_fragments_inside_bulleted_list() -> Result<()>
+    {
+        let list = list(vec![Block::nested(
+            list(vec!["A fragment\nAnother fragment".into()]).enumerate(),
+        )])
+        .bullet_list();
+        let mut result = String::new();
+
+        list.render(&mut result, 0)?;
+
+        verify_that!(result, eq("* 0. A fragment\n     Another fragment"))
+    }
+
+    fn list(blocks: Vec<Block>) -> List {
+        List(blocks, super::Decoration::None)
+    }
+}

--- a/googletest/src/internal/mod.rs
+++ b/googletest/src/internal/mod.rs
@@ -14,5 +14,6 @@
 
 #![doc(hidden)]
 
+pub(crate) mod description_renderer;
 pub mod source_location;
 pub mod test_outcome;

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -21,6 +21,7 @@ extern crate quickcheck;
 
 #[macro_use]
 pub mod assertions;
+pub mod description;
 pub mod internal;
 pub mod matcher;
 pub mod matcher_support;

--- a/googletest/src/matcher.rs
+++ b/googletest/src/matcher.rs
@@ -223,10 +223,10 @@ pub(crate) fn create_assertion_failure<T: Debug + ?Sized>(
 Value of: {actual_expr}
 Expected: {}
 Actual: {actual_formatted},
-  {}
+{}
 {source_location}",
         matcher.describe(MatcherResult::Match),
-        matcher.explain_match(actual),
+        matcher.explain_match(actual).indent(),
     ))
 }
 

--- a/googletest/src/matcher.rs
+++ b/googletest/src/matcher.rs
@@ -61,8 +61,10 @@ pub trait Matcher {
     /// fn describe(&self, matcher_result: MatcherResult) -> Description {
     ///     match matcher_result {
     ///         MatcherResult::Matches => {
-    ///             format!("has a value which {}", self.inner.describe(MatcherResult::Matches))
-    ///               //  Inner matcher invocation: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ///             Description::new()
+    ///                 .text("has a value which")
+    ///                 .nested(self.inner.describe(MatcherResult::Matches))
+    ///       // Inner matcher: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ///         }
     ///         MatcherResult::DoesNotMatch => {...} // Similar to the above
     ///     }
@@ -126,7 +128,9 @@ pub trait Matcher {
     ///
     /// ```ignore
     /// fn explain_match(&self, actual: &Self::ActualT) -> Description {
-    ///     format!("which points to a value {}", self.expected.explain_match(actual.deref()))
+    ///     Description::new()
+    ///         .text("which points to a value")
+    ///         .nested(self.expected.explain_match(actual.deref()))
     /// }
     /// ```
     fn explain_match(&self, actual: &Self::ActualT) -> Description {

--- a/googletest/src/matcher.rs
+++ b/googletest/src/matcher.rs
@@ -14,6 +14,7 @@
 
 //! The components required to implement matchers.
 
+use crate::description::Description;
 use crate::internal::source_location::SourceLocation;
 use crate::internal::test_outcome::TestAssertionFailure;
 use crate::matchers::__internal_unstable_do_not_depend_on_these::ConjunctionMatcher;
@@ -57,7 +58,7 @@ pub trait Matcher {
     /// [`some`][crate::matchers::some] implements `describe` as follows:
     ///
     /// ```ignore
-    /// fn describe(&self, matcher_result: MatcherResult) -> String {
+    /// fn describe(&self, matcher_result: MatcherResult) -> Description {
     ///     match matcher_result {
     ///         MatcherResult::Matches => {
     ///             format!("has a value which {}", self.inner.describe(MatcherResult::Matches))
@@ -75,7 +76,7 @@ pub trait Matcher {
     /// output of `explain_match` is always used adjectivally to describe the
     /// actual value, while `describe` is used in contexts where a relative
     /// clause would not make sense.
-    fn describe(&self, matcher_result: MatcherResult) -> String;
+    fn describe(&self, matcher_result: MatcherResult) -> Description;
 
     /// Prepares a [`String`] describing how the expected value
     /// encoded in this instance matches or does not match the given value
@@ -114,7 +115,7 @@ pub trait Matcher {
     /// inner matcher and appears as follows:
     ///
     /// ```ignore
-    /// fn explain_match(&self, actual: &Self::ActualT) -> String {
+    /// fn explain_match(&self, actual: &Self::ActualT) -> Description {
     ///     self.expected.explain_match(actual.deref())
     /// }
     /// ```
@@ -124,12 +125,12 @@ pub trait Matcher {
     /// inner matcher at a point where a relative clause would fit. For example:
     ///
     /// ```ignore
-    /// fn explain_match(&self, actual: &Self::ActualT) -> String {
+    /// fn explain_match(&self, actual: &Self::ActualT) -> Description {
     ///     format!("which points to a value {}", self.expected.explain_match(actual.deref()))
     /// }
     /// ```
-    fn explain_match(&self, actual: &Self::ActualT) -> String {
-        format!("which {}", self.describe(self.matches(actual)))
+    fn explain_match(&self, actual: &Self::ActualT) -> Description {
+        format!("which {}", self.describe(self.matches(actual))).into()
     }
 
     /// Constructs a matcher that matches both `self` and `right`.
@@ -240,7 +241,11 @@ pub enum MatcherResult {
 
 impl From<bool> for MatcherResult {
     fn from(b: bool) -> Self {
-        if b { MatcherResult::Match } else { MatcherResult::NoMatch }
+        if b {
+            MatcherResult::Match
+        } else {
+            MatcherResult::NoMatch
+        }
     }
 }
 

--- a/googletest/src/matcher_support/mod.rs
+++ b/googletest/src/matcher_support/mod.rs
@@ -19,7 +19,6 @@
 //! matchers.
 
 pub(crate) mod count_elements;
-pub mod description;
 pub(crate) mod edit_distance;
 pub(crate) mod summarize_diff;
 pub(crate) mod zipped_iterator;

--- a/googletest/src/matcher_support/summarize_diff.rs
+++ b/googletest/src/matcher_support/summarize_diff.rs
@@ -43,15 +43,19 @@ pub(crate) fn create_diff(
     }
     match edit_distance::edit_list(actual_debug.lines(), expected_debug.lines(), diff_mode) {
         edit_distance::Difference::Equal => "No difference found between debug strings.".into(),
-        edit_distance::Difference::Editable(edit_list) => format!(
+        edit_distance::Difference::Editable(edit_list) => indent(format!(
             "\nDifference({} / {}):{}",
             LineStyle::extra_actual_style().style("actual"),
             LineStyle::extra_expected_style().style("expected"),
             edit_list.into_iter().collect::<BufferedSummary>(),
-        )
+        ))
         .into(),
         edit_distance::Difference::Unrelated => "".into(),
     }
+}
+
+fn indent(string: impl AsRef<str>) -> String {
+    string.as_ref().lines().collect::<Vec<_>>().join("\n  ")
 }
 
 /// Returns a string describing how the expected and actual differ after
@@ -351,17 +355,14 @@ mod tests {
 
         verify_that!(
             create_diff(&build_text(1..50), &build_text(1..51), Mode::Exact),
-            eq(indoc! {
-                "
-
-                Difference(-actual / +expected):
-                 1
-                 2
-                 <---- 45 common lines omitted ---->
-                 48
-                 49
-                +50"
-            })
+            eq("
+  Difference(-actual / +expected):
+   1
+   2
+   <---- 45 common lines omitted ---->
+   48
+   49
+  +50")
         )
     }
 }

--- a/googletest/src/matcher_support/summarize_diff.rs
+++ b/googletest/src/matcher_support/summarize_diff.rs
@@ -43,19 +43,15 @@ pub(crate) fn create_diff(
     }
     match edit_distance::edit_list(actual_debug.lines(), expected_debug.lines(), diff_mode) {
         edit_distance::Difference::Equal => "No difference found between debug strings.".into(),
-        edit_distance::Difference::Editable(edit_list) => indent(format!(
+        edit_distance::Difference::Editable(edit_list) => format!(
             "\nDifference({} / {}):{}",
             LineStyle::extra_actual_style().style("actual"),
             LineStyle::extra_expected_style().style("expected"),
             edit_list.into_iter().collect::<BufferedSummary>(),
-        ))
+        )
         .into(),
         edit_distance::Difference::Unrelated => "".into(),
     }
-}
-
-fn indent(string: impl AsRef<str>) -> String {
-    string.as_ref().lines().collect::<Vec<_>>().join("\n  ")
 }
 
 /// Returns a string describing how the expected and actual differ after
@@ -355,14 +351,17 @@ mod tests {
 
         verify_that!(
             create_diff(&build_text(1..50), &build_text(1..51), Mode::Exact),
-            eq("
-  Difference(-actual / +expected):
-   1
-   2
-   <---- 45 common lines omitted ---->
-   48
-   49
-  +50")
+            eq(indoc! {
+                "
+
+                Difference(-actual / +expected):
+                 1
+                 2
+                 <---- 45 common lines omitted ---->
+                 48
+                 49
+                +50"
+            })
         )
     }
 }

--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -102,7 +102,7 @@ pub mod internal {
             MatcherResult::Match
         }
 
-        fn explain_match(&self, actual: &Self::ActualT) -> String {
+        fn explain_match(&self, actual: &Self::ActualT) -> Description {
             match N {
                 0 => anything::<T>().explain_match(actual),
                 1 => self.components[0].explain_match(actual),
@@ -114,15 +114,15 @@ pub mod internal {
                         .map(|component| component.explain_match(actual))
                         .collect::<Description>();
                     if failures.len() == 1 {
-                        format!("{}", failures)
+                        format!("{}", failures).into()
                     } else {
-                        format!("{}", failures.bullet_list().indent_except_first_line())
+                        format!("{}", failures.bullet_list().indent_except_first_line()).into()
                     }
                 }
             }
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             match N {
                 0 => anything::<T>().describe(matcher_result),
                 1 => self.components[0].describe(matcher_result),
@@ -142,6 +142,7 @@ pub mod internal {
                             "has at least one of the following properties"
                         }
                     )
+                    .into()
                 }
             }
         }

--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -163,12 +163,12 @@ mod tests {
 
         verify_that!(
             matcher.describe(MatcherResult::Match),
-            eq(indoc!(
+            displays_as(eq(indoc!(
                 "
                 has all the following properties:
                   * starts with prefix \"A\"
                   * ends with suffix \"string\""
-            ))
+            )))
         )
     }
 
@@ -177,7 +177,10 @@ mod tests {
         let first_matcher = starts_with("A");
         let matcher: internal::AllMatcher<String, 1> = all!(first_matcher);
 
-        verify_that!(matcher.describe(MatcherResult::Match), eq("starts with prefix \"A\""))
+        verify_that!(
+            matcher.describe(MatcherResult::Match),
+            displays_as(eq("starts with prefix \"A\""))
+        )
     }
 
     #[test]

--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -64,8 +64,8 @@ macro_rules! __all {
 /// For internal use only. API stablility is not guaranteed!
 #[doc(hidden)]
 pub mod internal {
+    use crate::description::Description;
     use crate::matcher::{Matcher, MatcherResult};
-    use crate::matcher_support::description::Description;
     use crate::matchers::anything;
     use std::fmt::Debug;
 

--- a/googletest/src/matchers/any_matcher.rs
+++ b/googletest/src/matchers/any_matcher.rs
@@ -66,8 +66,8 @@ macro_rules! __any {
 /// For internal use only. API stablility is not guaranteed!
 #[doc(hidden)]
 pub mod internal {
+    use crate::description::Description;
     use crate::matcher::{Matcher, MatcherResult};
-    use crate::matcher_support::description::Description;
     use crate::matchers::anything;
     use std::fmt::Debug;
 

--- a/googletest/src/matchers/any_matcher.rs
+++ b/googletest/src/matchers/any_matcher.rs
@@ -96,9 +96,9 @@ pub mod internal {
             MatcherResult::from(self.components.iter().any(|c| c.matches(actual).is_match()))
         }
 
-        fn explain_match(&self, actual: &Self::ActualT) -> String {
+        fn explain_match(&self, actual: &Self::ActualT) -> Description {
             match N {
-                0 => format!("which {}", anything::<T>().describe(MatcherResult::NoMatch)),
+                0 => format!("which {}", anything::<T>().describe(MatcherResult::NoMatch)).into(),
                 1 => self.components[0].explain_match(actual),
                 _ => {
                     let failures = self
@@ -108,15 +108,15 @@ pub mod internal {
                         .map(|component| component.explain_match(actual))
                         .collect::<Description>();
                     if failures.len() == 1 {
-                        format!("{}", failures)
+                        format!("{}", failures).into()
                     } else {
-                        format!("{}", failures.bullet_list().indent_except_first_line())
+                        format!("{}", failures.bullet_list().indent_except_first_line()).into()
                     }
                 }
             }
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             match N {
                 0 => anything::<T>().describe(matcher_result),
                 1 => self.components[0].describe(matcher_result),
@@ -136,6 +136,7 @@ pub mod internal {
                             "has none of the following properties"
                         }
                     )
+                    .into()
                 }
             }
         }

--- a/googletest/src/matchers/any_matcher.rs
+++ b/googletest/src/matchers/any_matcher.rs
@@ -157,12 +157,12 @@ mod tests {
 
         verify_that!(
             matcher.describe(MatcherResult::Match),
-            eq(indoc!(
+            displays_as(eq(indoc!(
                 "
                 has at least one of the following properties:
                   * starts with prefix \"A\"
                   * ends with suffix \"string\""
-            ))
+            )))
         )
     }
 
@@ -171,7 +171,10 @@ mod tests {
         let first_matcher = starts_with("A");
         let matcher: internal::AnyMatcher<String, 1> = any!(first_matcher);
 
-        verify_that!(matcher.describe(MatcherResult::Match), eq("starts with prefix \"A\""))
+        verify_that!(
+            matcher.describe(MatcherResult::Match),
+            displays_as(eq("starts with prefix \"A\""))
+        )
     }
 
     #[test]

--- a/googletest/src/matchers/any_matcher.rs
+++ b/googletest/src/matchers/any_matcher.rs
@@ -105,12 +105,18 @@ pub mod internal {
                         .components
                         .iter()
                         .filter(|component| component.matches(actual).is_no_match())
-                        .map(|component| component.explain_match(actual))
-                        .collect::<Description>();
+                        .collect::<Vec<_>>();
+
                     if failures.len() == 1 {
-                        format!("{}", failures).into()
+                        failures[0].explain_match(actual)
                     } else {
-                        format!("{}", failures.bullet_list().indent_except_first_line()).into()
+                        Description::new()
+                            .collect(
+                                failures
+                                    .into_iter()
+                                    .map(|component| component.explain_match(actual)),
+                            )
+                            .bullet_list()
                     }
                 }
             }

--- a/googletest/src/matchers/anything_matcher.rs
+++ b/googletest/src/matchers/anything_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches anything. This matcher always succeeds.
@@ -42,10 +45,10 @@ impl<T: Debug + ?Sized> Matcher for Anything<T> {
         MatcherResult::Match
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => "is anything".to_string(),
-            MatcherResult::NoMatch => "never matches".to_string(),
+            MatcherResult::Match => "is anything".into(),
+            MatcherResult::NoMatch => "never matches".into(),
         }
     }
 }

--- a/googletest/src/matchers/char_count_matcher.rs
+++ b/googletest/src/matchers/char_count_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a string whose number of Unicode scalars matches `expected`.
@@ -71,36 +74,36 @@ impl<T: Debug + ?Sized + AsRef<str>, E: Matcher<ActualT = usize>> Matcher for Ch
         self.expected.matches(&actual.as_ref().chars().count())
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => {
-                format!(
-                    "has character count, which {}",
-                    self.expected.describe(MatcherResult::Match)
-                )
-            }
-            MatcherResult::NoMatch => {
-                format!(
-                    "has character count, which {}",
-                    self.expected.describe(MatcherResult::NoMatch)
-                )
-            }
+            MatcherResult::Match => format!(
+                "has character count, which {}",
+                self.expected.describe(MatcherResult::Match)
+            )
+            .into(),
+            MatcherResult::NoMatch => format!(
+                "has character count, which {}",
+                self.expected.describe(MatcherResult::NoMatch)
+            )
+            .into(),
         }
     }
 
-    fn explain_match(&self, actual: &T) -> String {
+    fn explain_match(&self, actual: &T) -> Description {
         let actual_size = actual.as_ref().chars().count();
         format!(
             "which has character count {}, {}",
             actual_size,
             self.expected.explain_match(&actual_size)
         )
+        .into()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::char_count;
+    use crate::description::Description;
     use crate::matcher::{Matcher, MatcherResult};
     use crate::prelude::*;
     use indoc::indoc;
@@ -135,11 +138,11 @@ mod tests {
                 false.into()
             }
 
-            fn describe(&self, _: MatcherResult) -> String {
+            fn describe(&self, _: MatcherResult) -> Description {
                 "called described".into()
             }
 
-            fn explain_match(&self, _: &T) -> String {
+            fn explain_match(&self, _: &T) -> Description {
                 "called explain_match".into()
             }
         }

--- a/googletest/src/matchers/conjunction_matcher.rs
+++ b/googletest/src/matchers/conjunction_matcher.rs
@@ -51,20 +51,16 @@ where
 
     fn explain_match(&self, actual: &M1::ActualT) -> Description {
         match (self.m1.matches(actual), self.m2.matches(actual)) {
-            (MatcherResult::Match, MatcherResult::Match) => format!(
-                "{} and\n  {}",
-                self.m1.explain_match(actual),
-                self.m2.explain_match(actual)
-            )
-            .into(),
+            (MatcherResult::Match, MatcherResult::Match) => Description::new()
+                .nested(self.m1.explain_match(actual))
+                .text("and")
+                .nested(self.m2.explain_match(actual)),
             (MatcherResult::NoMatch, MatcherResult::Match) => self.m1.explain_match(actual),
             (MatcherResult::Match, MatcherResult::NoMatch) => self.m2.explain_match(actual),
-            (MatcherResult::NoMatch, MatcherResult::NoMatch) => format!(
-                "{} and\n  {}",
-                self.m1.explain_match(actual),
-                self.m2.explain_match(actual)
-            )
-            .into(),
+            (MatcherResult::NoMatch, MatcherResult::NoMatch) => Description::new()
+                .nested(self.m1.explain_match(actual))
+                .text("and")
+                .nested(self.m2.explain_match(actual)),
         }
     }
 
@@ -126,8 +122,9 @@ mod tests {
                 Value of: 1
                 Expected: never matches, and never matches
                 Actual: 1,
-                  which is anything and
-                  which is anything
+                    which is anything
+                  and
+                    which is anything
                 "
             ))))
         )

--- a/googletest/src/matchers/conjunction_matcher.rs
+++ b/googletest/src/matchers/conjunction_matcher.rs
@@ -15,7 +15,10 @@
 // There are no visible documentation elements in this module.
 #![doc(hidden)]
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::fmt::Debug;
 
 /// Matcher created by [`Matcher::and`].
@@ -46,29 +49,28 @@ where
         }
     }
 
-    fn explain_match(&self, actual: &M1::ActualT) -> String {
+    fn explain_match(&self, actual: &M1::ActualT) -> Description {
         match (self.m1.matches(actual), self.m2.matches(actual)) {
-            (MatcherResult::Match, MatcherResult::Match) => {
-                format!(
-                    "{} and\n  {}",
-                    self.m1.explain_match(actual),
-                    self.m2.explain_match(actual)
-                )
-            }
+            (MatcherResult::Match, MatcherResult::Match) => format!(
+                "{} and\n  {}",
+                self.m1.explain_match(actual),
+                self.m2.explain_match(actual)
+            )
+            .into(),
             (MatcherResult::NoMatch, MatcherResult::Match) => self.m1.explain_match(actual),
             (MatcherResult::Match, MatcherResult::NoMatch) => self.m2.explain_match(actual),
-            (MatcherResult::NoMatch, MatcherResult::NoMatch) => {
-                format!(
-                    "{} and\n  {}",
-                    self.m1.explain_match(actual),
-                    self.m2.explain_match(actual)
-                )
-            }
+            (MatcherResult::NoMatch, MatcherResult::NoMatch) => format!(
+                "{} and\n  {}",
+                self.m1.explain_match(actual),
+                self.m2.explain_match(actual)
+            )
+            .into(),
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         format!("{}, and {}", self.m1.describe(matcher_result), self.m2.describe(matcher_result))
+            .into()
     }
 }
 

--- a/googletest/src/matchers/container_eq_matcher.rs
+++ b/googletest/src/matchers/container_eq_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -119,14 +120,14 @@ where
         (*actual == self.expected).into()
     }
 
-    fn explain_match(&self, actual: &ActualContainerT) -> String {
-        build_explanation(self.get_missing_items(actual), self.get_unexpected_items(actual))
+    fn explain_match(&self, actual: &ActualContainerT) -> Description {
+        build_explanation(self.get_missing_items(actual), self.get_unexpected_items(actual)).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is equal to {:?}", self.expected),
-            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected),
+            MatcherResult::Match => format!("is equal to {:?}", self.expected).into(),
+            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected).into(),
         }
     }
 }
@@ -270,15 +271,15 @@ mod tests {
     }
 
     #[test]
-    fn container_eq_matches_owned_vec_of_owned_strings_with_slice_of_string_references()
-    -> Result<()> {
+    fn container_eq_matches_owned_vec_of_owned_strings_with_slice_of_string_references(
+    ) -> Result<()> {
         let vector = vec!["A string".to_string(), "Another string".to_string()];
         verify_that!(vector, container_eq(["A string", "Another string"]))
     }
 
     #[test]
-    fn container_eq_matches_owned_vec_of_owned_strings_with_shorter_slice_of_string_references()
-    -> Result<()> {
+    fn container_eq_matches_owned_vec_of_owned_strings_with_shorter_slice_of_string_references(
+    ) -> Result<()> {
         let actual = vec!["A string".to_string(), "Another string".to_string()];
         let matcher = container_eq(["A string"]);
 

--- a/googletest/src/matchers/contains_matcher.rs
+++ b/googletest/src/matchers/contains_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches an iterable type whose elements contain a value matched by `inner`.
@@ -101,33 +104,37 @@ where
         }
     }
 
-    fn explain_match(&self, actual: &Self::ActualT) -> String {
+    fn explain_match(&self, actual: &Self::ActualT) -> Description {
         let count = self.count_matches(actual);
         match (count, &self.count) {
-            (_, Some(_)) => format!("which contains {} matching elements", count),
-            (0, None) => "which does not contain a matching element".to_string(),
-            (_, None) => "which contains a matching element".to_string(),
+            (_, Some(_)) => format!("which contains {} matching elements", count).into(),
+            (0, None) => "which does not contain a matching element".into(),
+            (_, None) => "which contains a matching element".into(),
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match (matcher_result, &self.count) {
             (MatcherResult::Match, Some(count)) => format!(
                 "contains n elements which {}\n  where n {}",
                 self.inner.describe(MatcherResult::Match),
                 count.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
             (MatcherResult::NoMatch, Some(count)) => format!(
                 "doesn't contain n elements which {}\n  where n {}",
                 self.inner.describe(MatcherResult::Match),
                 count.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
             (MatcherResult::Match, None) => format!(
                 "contains at least one element which {}",
                 self.inner.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
             (MatcherResult::NoMatch, None) => {
                 format!("contains no element which {}", self.inner.describe(MatcherResult::Match))
+                    .into()
             }
         }
     }

--- a/googletest/src/matchers/contains_matcher.rs
+++ b/googletest/src/matchers/contains_matcher.rs
@@ -233,7 +233,7 @@ mod tests {
 
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("contains at least one element which is equal to 1")
+            displays_as(eq("contains at least one element which is equal to 1"))
         )
     }
 
@@ -243,7 +243,7 @@ mod tests {
 
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("contains n elements which is equal to 1\n  where n is equal to 2")
+            displays_as(eq("contains n elements which is equal to 1\n  where n is equal to 2"))
         )
     }
 

--- a/googletest/src/matchers/contains_regex_matcher.rs
+++ b/googletest/src/matchers/contains_regex_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use regex::Regex;
 use std::fmt::Debug;
@@ -77,13 +78,13 @@ impl<ActualT: AsRef<str> + Debug + ?Sized> Matcher for ContainsRegexMatcher<Actu
         self.regex.is_match(actual.as_ref()).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
-                format!("contains the regular expression {:#?}", self.regex.as_str())
+                format!("contains the regular expression {:#?}", self.regex.as_str()).into()
             }
             MatcherResult::NoMatch => {
-                format!("doesn't contain the regular expression {:#?}", self.regex.as_str())
+                format!("doesn't contain the regular expression {:#?}", self.regex.as_str()).into()
             }
         }
     }

--- a/googletest/src/matchers/contains_regex_matcher.rs
+++ b/googletest/src/matchers/contains_regex_matcher.rs
@@ -142,7 +142,7 @@ mod tests {
 
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("contains the regular expression \"\\n\"")
+            displays_as(eq("contains the regular expression \"\\n\""))
         )
     }
 }

--- a/googletest/src/matchers/disjunction_matcher.rs
+++ b/googletest/src/matchers/disjunction_matcher.rs
@@ -15,7 +15,10 @@
 // There are no visible documentation elements in this module.
 #![doc(hidden)]
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::fmt::Debug;
 
 /// Matcher created by [`Matcher::or`].
@@ -46,12 +49,13 @@ where
         }
     }
 
-    fn explain_match(&self, actual: &M1::ActualT) -> String {
-        format!("{} and\n  {}", self.m1.explain_match(actual), self.m2.explain_match(actual))
+    fn explain_match(&self, actual: &M1::ActualT) -> Description {
+        format!("{} and\n  {}", self.m1.explain_match(actual), self.m2.explain_match(actual)).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         format!("{}, or {}", self.m1.describe(matcher_result), self.m2.describe(matcher_result))
+            .into()
     }
 }
 

--- a/googletest/src/matchers/disjunction_matcher.rs
+++ b/googletest/src/matchers/disjunction_matcher.rs
@@ -50,7 +50,10 @@ where
     }
 
     fn explain_match(&self, actual: &M1::ActualT) -> Description {
-        format!("{} and\n  {}", self.m1.explain_match(actual), self.m2.explain_match(actual)).into()
+        Description::new()
+            .nested(self.m1.explain_match(actual))
+            .text("and")
+            .nested(self.m2.explain_match(actual))
     }
 
     fn describe(&self, matcher_result: MatcherResult) -> Description {
@@ -89,8 +92,9 @@ mod tests {
                 Value of: 1
                 Expected: never matches, or never matches
                 Actual: 1,
-                  which is anything and
-                  which is anything
+                    which is anything
+                  and
+                    which is anything
                 "
             ))))
         )

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
@@ -42,19 +43,22 @@ impl<T: Debug + Display, InnerMatcher: Matcher<ActualT = String>> Matcher
         self.inner.matches(&format!("{actual}"))
     }
 
-    fn explain_match(&self, actual: &T) -> String {
+    fn explain_match(&self, actual: &T) -> Description {
         format!("which displays as a string {}", self.inner.explain_match(&format!("{actual}")))
+            .into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
                 format!("displays as a string which {}", self.inner.describe(MatcherResult::Match))
+                    .into()
             }
             MatcherResult::NoMatch => format!(
                 "doesn't display as a string which {}",
                 self.inner.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
         }
     }
 }

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -51,12 +51,10 @@ impl<T: Debug + Display, InnerMatcher: Matcher<ActualT = String>> Matcher
             MatcherResult::Match => {
                 format!("displays as a string which {}", self.inner.describe(MatcherResult::Match))
             }
-            MatcherResult::NoMatch => {
-                format!(
-                    "doesn't display as a string which {}",
-                    self.inner.describe(MatcherResult::Match)
-                )
-            }
+            MatcherResult::NoMatch => format!(
+                "doesn't display as a string which {}",
+                self.inner.describe(MatcherResult::Match)
+            ),
         }
     }
 }
@@ -107,6 +105,7 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc!(
                 "
+                  Actual: \"123\\n234\",
                     which displays as a string which isn't equal to \"123\\n345\"
                     Difference(-actual / +expected):
                      123

--- a/googletest/src/matchers/each_matcher.rs
+++ b/googletest/src/matchers/each_matcher.rs
@@ -228,8 +228,8 @@ mod tests {
                 Expected: only contains elements that is greater than 1
                 Actual: [0, 1, 3],
                   whose elements #0, #1 don't match
-                  0, which is less than or equal to 1
-                  1, which is less than or equal to 1"
+                    0, which is less than or equal to 1
+                    1, which is less than or equal to 1"
             ))))
         )
     }

--- a/googletest/src/matchers/each_matcher.rs
+++ b/googletest/src/matchers/each_matcher.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
-use crate::matcher_support::description::Description;
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a container all of whose elements are matched by the matcher

--- a/googletest/src/matchers/each_matcher.rs
+++ b/googletest/src/matchers/each_matcher.rs
@@ -92,7 +92,7 @@ where
         MatcherResult::Match
     }
 
-    fn explain_match(&self, actual: &ActualT) -> String {
+    fn explain_match(&self, actual: &ActualT) -> Description {
         let mut non_matching_elements = Vec::new();
         for (index, element) in actual.into_iter().enumerate() {
             if self.inner.matches(element).is_no_match() {
@@ -100,11 +100,12 @@ where
             }
         }
         if non_matching_elements.is_empty() {
-            return format!("whose each element {}", self.inner.describe(MatcherResult::Match));
+            return format!("whose each element {}", self.inner.describe(MatcherResult::Match))
+                .into();
         }
         if non_matching_elements.len() == 1 {
             let (idx, element, explanation) = non_matching_elements.remove(0);
-            return format!("whose element #{idx} is {element:?}, {explanation}");
+            return format!("whose element #{idx} is {element:?}, {explanation}").into();
         }
 
         let failed_indexes = non_matching_elements
@@ -117,16 +118,18 @@ where
             .map(|&(_, element, ref explanation)| format!("{element:?}, {explanation}"))
             .collect::<Description>()
             .indent();
-        format!("whose elements {failed_indexes} don't match\n{element_explanations}")
+        format!("whose elements {failed_indexes} don't match\n{element_explanations}").into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
                 format!("only contains elements that {}", self.inner.describe(MatcherResult::Match))
+                    .into()
             }
             MatcherResult::NoMatch => {
                 format!("contains no element that {}", self.inner.describe(MatcherResult::Match))
+                    .into()
             }
         }
     }

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -136,7 +136,7 @@ pub mod internal {
             }
         }
 
-        fn explain_match(&self, actual: &ContainerT) -> String {
+        fn explain_match(&self, actual: &ContainerT) -> Description {
             let actual_iterator = actual.into_iter();
             let mut zipped_iterator = zip(actual_iterator, self.elements.iter());
             let mut mismatches = Vec::new();
@@ -147,20 +147,20 @@ pub mod internal {
             }
             if mismatches.is_empty() {
                 if !zipped_iterator.has_size_mismatch() {
-                    "whose elements all match".to_string()
+                    "whose elements all match".into()
                 } else {
-                    format!("whose size is {}", zipped_iterator.left_size())
+                    format!("whose size is {}", zipped_iterator.left_size()).into()
                 }
             } else if mismatches.len() == 1 {
                 let mismatches = mismatches.into_iter().collect::<Description>();
-                format!("where {mismatches}")
+                format!("where {mismatches}").into()
             } else {
                 let mismatches = mismatches.into_iter().collect::<Description>();
-                format!("where:\n{}", mismatches.bullet_list().indent())
+                format!("where:\n{}", mismatches.bullet_list().indent()).into()
             }
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             format!(
                 "{} elements:\n{}",
                 if matcher_result.into() { "has" } else { "doesn't have" },
@@ -172,6 +172,7 @@ pub mod internal {
                     .enumerate()
                     .indent()
             )
+            .into()
         }
     }
 }

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -92,8 +92,8 @@ macro_rules! __elements_are {
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
 pub mod internal {
+    use crate::description::Description;
     use crate::matcher::{Matcher, MatcherResult};
-    use crate::matcher_support::description::Description;
     use crate::matcher_support::zipped_iterator::zip;
     use std::{fmt::Debug, marker::PhantomData};
 

--- a/googletest/src/matchers/empty_matcher.rs
+++ b/googletest/src/matchers/empty_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches an empty container.
@@ -68,8 +71,8 @@ where
         actual.into_iter().next().is_none().into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
-        if matcher_result.into() { "is empty" } else { "isn't empty" }.to_string()
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
+        if matcher_result.into() { "is empty" } else { "isn't empty" }.into()
     }
 }
 

--- a/googletest/src/matchers/eq_deref_of_matcher.rs
+++ b/googletest/src/matchers/eq_deref_of_matcher.rs
@@ -138,13 +138,13 @@ mod tests {
             "
             Actual: Strukt { int: 123, string: \"something\" },
               which isn't equal to Strukt { int: 321, string: \"someone\" }
-            Difference(-actual / +expected):
-             Strukt {
-            -    int: 123,
-            +    int: 321,
-            -    string: \"something\",
-            +    string: \"someone\",
-             }
+              Difference(-actual / +expected):
+               Strukt {
+              -    int: 123,
+              +    int: 321,
+              -    string: \"something\",
+              +    string: \"someone\",
+               }
             "})))
         )
     }

--- a/googletest/src/matchers/eq_deref_of_matcher.rs
+++ b/googletest/src/matchers/eq_deref_of_matcher.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{
+    description::Description,
     matcher::{Matcher, MatcherResult},
     matcher_support::{edit_distance, summarize_diff::create_diff},
 };
@@ -76,14 +77,14 @@ where
         (self.expected.deref() == actual).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is equal to {:?}", self.expected),
-            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected),
+            MatcherResult::Match => format!("is equal to {:?}", self.expected).into(),
+            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected).into(),
         }
     }
 
-    fn explain_match(&self, actual: &ActualT) -> String {
+    fn explain_match(&self, actual: &ActualT) -> Description {
         format!(
             "which {}{}",
             &self.describe(self.matches(actual)),
@@ -93,6 +94,7 @@ where
                 edit_distance::Mode::Exact,
             )
         )
+        .into()
     }
 }
 

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use crate::matcher_support::edit_distance;
 use crate::matcher_support::summarize_diff::create_diff;
@@ -89,14 +90,14 @@ impl<A: Debug + ?Sized, T: PartialEq<A> + Debug> Matcher for EqMatcher<A, T> {
         (self.expected == *actual).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is equal to {:?}", self.expected),
-            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected),
+            MatcherResult::Match => format!("is equal to {:?}", self.expected).into(),
+            MatcherResult::NoMatch => format!("isn't equal to {:?}", self.expected).into(),
         }
     }
 
-    fn explain_match(&self, actual: &A) -> String {
+    fn explain_match(&self, actual: &A) -> Description {
         let expected_debug = format!("{:#?}", self.expected);
         let actual_debug = format!("{:#?}", actual);
         let description = self.describe(self.matches(actual));
@@ -117,7 +118,7 @@ impl<A: Debug + ?Sized, T: PartialEq<A> + Debug> Matcher for EqMatcher<A, T> {
             create_diff(&actual_debug, &expected_debug, edit_distance::Mode::Exact)
         };
 
-        format!("which {description}{diff}")
+        format!("which {description}{diff}").into()
     }
 }
 

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -178,13 +178,13 @@ mod tests {
             "
             Actual: Strukt { int: 123, string: \"something\" },
               which isn't equal to Strukt { int: 321, string: \"someone\" }
-            Difference(-actual / +expected):
-             Strukt {
-            -    int: 123,
-            +    int: 321,
-            -    string: \"something\",
-            +    string: \"someone\",
-             }
+              Difference(-actual / +expected):
+               Strukt {
+              -    int: 123,
+              +    int: 321,
+              -    string: \"something\",
+              +    string: \"someone\",
+               }
             "})))
         )
     }
@@ -200,13 +200,13 @@ mod tests {
             Expected: is equal to [1, 3, 4]
             Actual: [1, 2, 3],
               which isn't equal to [1, 3, 4]
-            Difference(-actual / +expected):
-             [
-                 1,
-            -    2,
-                 3,
-            +    4,
-             ]
+              Difference(-actual / +expected):
+               [
+                   1,
+              -    2,
+                   3,
+              +    4,
+               ]
             "})))
         )
     }
@@ -222,14 +222,14 @@ mod tests {
             Expected: is equal to [1, 3, 5]
             Actual: [1, 2, 3, 4, 5],
               which isn't equal to [1, 3, 5]
-            Difference(-actual / +expected):
-             [
-                 1,
-            -    2,
-                 3,
-            -    4,
-                 5,
-             ]
+              Difference(-actual / +expected):
+               [
+                   1,
+              -    2,
+                   3,
+              -    4,
+                   5,
+               ]
             "})))
         )
     }
@@ -241,18 +241,20 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-actual / +expected):
-             [
-            -    1,
-            -    2,
-                 3,
-                 4,
-             <---- 43 common lines omitted ---->
-                 48,
-                 49,
-            +    50,
-            +    51,
-             ]"})))
+            ],
+              which isn't equal to [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+              Difference(-actual / +expected):
+               [
+              -    1,
+              -    2,
+                   3,
+                   4,
+               <---- 43 common lines omitted ---->
+                   48,
+                   49,
+              +    50,
+              +    51,
+               ]"})))
         )
     }
 
@@ -263,18 +265,20 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-actual / +expected):
-             [
-            -    1,
-            -    2,
-                 3,
-                 4,
-                 5,
-                 6,
-                 7,
-            +    8,
-            +    9,
-             ]"})))
+            Actual: [1, 2, 3, 4, 5, 6, 7],
+              which isn't equal to [3, 4, 5, 6, 7, 8, 9]
+              Difference(-actual / +expected):
+               [
+              -    1,
+              -    2,
+                   3,
+                   4,
+                   5,
+                   6,
+                   7,
+              +    8,
+              +    9,
+               ]"})))
         )
     }
 
@@ -285,15 +289,17 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-actual / +expected):
-             [
-                 1,
-             <---- 46 common lines omitted ---->
-                 48,
-                 49,
-            +    50,
-            +    51,
-             ]"})))
+            ],
+              which isn't equal to [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+              Difference(-actual / +expected):
+               [
+                   1,
+               <---- 46 common lines omitted ---->
+                   48,
+                   49,
+              +    50,
+              +    51,
+               ]"})))
         )
     }
 
@@ -304,15 +310,17 @@ mod tests {
             result,
             err(displays_as(contains_substring(indoc! {
             "
-            Difference(-actual / +expected):
-             [
-            -    1,
-            -    2,
-                 3,
-                 4,
-             <---- 46 common lines omitted ---->
-                 51,
-             ]"})))
+            ],
+              which isn't equal to [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+              Difference(-actual / +expected):
+               [
+              -    1,
+              -    2,
+                   3,
+                   4,
+               <---- 46 common lines omitted ---->
+                   51,
+               ]"})))
         )
     }
 
@@ -354,14 +362,13 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(contains_substring(indoc!(
-                "
-                 First line
-                -Second line
-                +Second lines
-                 Third line
-                "
-            ))))
+            err(displays_as(contains_substring(
+                "\
+   First line
+  -Second line
+  +Second lines
+   Third line"
+            )))
         )
     }
 

--- a/googletest/src/matchers/err_matcher.rs
+++ b/googletest/src/matchers/err_matcher.rs
@@ -139,6 +139,9 @@ mod tests {
             phantom_t: Default::default(),
             phantom_e: Default::default(),
         };
-        verify_that!(matcher.describe(MatcherResult::Match), eq("is an error which is equal to 1"))
+        verify_that!(
+            matcher.describe(MatcherResult::Match),
+            displays_as(eq("is an error which is equal to 1"))
+        )
     }
 }

--- a/googletest/src/matchers/err_matcher.rs
+++ b/googletest/src/matchers/err_matcher.rs
@@ -61,7 +61,9 @@ impl<T: Debug, E: Debug, InnerMatcherT: Matcher<ActualT = E>> Matcher
 
     fn explain_match(&self, actual: &Self::ActualT) -> Description {
         match actual {
-            Err(e) => format!("which is an error {}", self.inner.explain_match(e)).into(),
+            Err(e) => {
+                Description::new().text("which is an error").nested(self.inner.explain_match(e))
+            }
             Ok(_) => "which is a success".into(),
         }
     }
@@ -128,7 +130,8 @@ mod tests {
                     Value of: Err::<i32, i32>(1)
                     Expected: is an error which is equal to 2
                     Actual: Err(1),
-                      which is an error which isn't equal to 2
+                      which is an error
+                        which isn't equal to 2
                 "
             ))))
         )

--- a/googletest/src/matchers/err_matcher.rs
+++ b/googletest/src/matchers/err_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a `Result` containing `Err` with a value matched by `inner`.
@@ -56,24 +59,23 @@ impl<T: Debug, E: Debug, InnerMatcherT: Matcher<ActualT = E>> Matcher
         actual.as_ref().err().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::NoMatch)
     }
 
-    fn explain_match(&self, actual: &Self::ActualT) -> String {
+    fn explain_match(&self, actual: &Self::ActualT) -> Description {
         match actual {
-            Err(e) => format!("which is an error {}", self.inner.explain_match(e)),
-            Ok(_) => "which is a success".to_string(),
+            Err(e) => format!("which is an error {}", self.inner.explain_match(e)).into(),
+            Ok(_) => "which is a success".into(),
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
-                format!("is an error which {}", self.inner.describe(MatcherResult::Match))
+                format!("is an error which {}", self.inner.describe(MatcherResult::Match)).into()
             }
-            MatcherResult::NoMatch => {
-                format!(
-                    "is a success or is an error containing a value which {}",
-                    self.inner.describe(MatcherResult::NoMatch)
-                )
-            }
+            MatcherResult::NoMatch => format!(
+                "is a success or is an error containing a value which {}",
+                self.inner.describe(MatcherResult::NoMatch)
+            )
+            .into(),
         }
     }
 }

--- a/googletest/src/matchers/field_matcher.rs
+++ b/googletest/src/matchers/field_matcher.rs
@@ -141,7 +141,10 @@ macro_rules! field_internal {
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
 pub mod internal {
-    use crate::matcher::{Matcher, MatcherResult};
+    use crate::{
+        description::Description,
+        matcher::{Matcher, MatcherResult},
+    };
     use std::fmt::Debug;
 
     /// Creates a matcher to verify a specific field of the actual struct using
@@ -176,27 +179,29 @@ pub mod internal {
             }
         }
 
-        fn explain_match(&self, actual: &OuterT) -> String {
+        fn explain_match(&self, actual: &OuterT) -> Description {
             if let Some(actual) = (self.field_accessor)(actual) {
                 format!(
                     "which has field `{}`, {}",
                     self.field_path,
                     self.inner.explain_match(actual)
                 )
+                .into()
             } else {
                 let formatted_actual_value = format!("{actual:?}");
                 let without_fields = formatted_actual_value.split('(').next().unwrap_or("");
                 let without_fields = without_fields.split('{').next().unwrap_or("").trim_end();
-                format!("which has the wrong enum variant `{without_fields}`")
+                format!("which has the wrong enum variant `{without_fields}`").into()
             }
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             format!(
                 "has field `{}`, which {}",
                 self.field_path,
                 self.inner.describe(matcher_result)
             )
+            .into()
         }
     }
 }

--- a/googletest/src/matchers/ge_matcher.rs
+++ b/googletest/src/matchers/ge_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value greater than or equal to (in the sense of `>=`) `expected`.
@@ -91,10 +94,12 @@ impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
         (*actual >= self.expected).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is greater than or equal to {:?}", self.expected),
-            MatcherResult::NoMatch => format!("is less than {:?}", self.expected),
+            MatcherResult::Match => {
+                format!("is greater than or equal to {:?}", self.expected).into()
+            }
+            MatcherResult::NoMatch => format!("is less than {:?}", self.expected).into(),
         }
     }
 }

--- a/googletest/src/matchers/gt_matcher.rs
+++ b/googletest/src/matchers/gt_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value greater (in the sense of `>`) than `expected`.
@@ -91,10 +94,12 @@ impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
         (*actual > self.expected).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is greater than {:?}", self.expected),
-            MatcherResult::NoMatch => format!("is less than or equal to {:?}", self.expected),
+            MatcherResult::Match => format!("is greater than {:?}", self.expected).into(),
+            MatcherResult::NoMatch => {
+                format!("is less than or equal to {:?}", self.expected).into()
+            }
         }
     }
 }

--- a/googletest/src/matchers/gt_matcher.rs
+++ b/googletest/src/matchers/gt_matcher.rs
@@ -175,14 +175,17 @@ mod tests {
 
     #[test]
     fn gt_describe_matches() -> Result<()> {
-        verify_that!(gt::<i32, i32>(232).describe(MatcherResult::Match), eq("is greater than 232"))
+        verify_that!(
+            gt::<i32, i32>(232).describe(MatcherResult::Match),
+            displays_as(eq("is greater than 232"))
+        )
     }
 
     #[test]
     fn gt_describe_does_not_match() -> Result<()> {
         verify_that!(
             gt::<i32, i32>(232).describe(MatcherResult::NoMatch),
-            eq("is less than or equal to 232")
+            displays_as(eq("is less than or equal to 232"))
         )
     }
 

--- a/googletest/src/matchers/has_entry_matcher.rs
+++ b/googletest/src/matchers/has_entry_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -87,7 +88,7 @@ impl<KeyT: Debug + Eq + Hash, ValueT: Debug, MatcherT: Matcher<ActualT = ValueT>
         }
     }
 
-    fn explain_match(&self, actual: &HashMap<KeyT, ValueT>) -> String {
+    fn explain_match(&self, actual: &HashMap<KeyT, ValueT>) -> Description {
         if let Some(value) = actual.get(&self.key) {
             format!(
                 "which contains key {:?}, but is mapped to value {:#?}, {}",
@@ -95,24 +96,27 @@ impl<KeyT: Debug + Eq + Hash, ValueT: Debug, MatcherT: Matcher<ActualT = ValueT>
                 value,
                 self.inner.explain_match(value)
             )
+            .into()
         } else {
-            format!("which doesn't contain key {:?}", self.key)
+            format!("which doesn't contain key {:?}", self.key).into()
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => format!(
                 "contains key {:?}, which value {}",
                 self.key,
                 self.inner.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
             MatcherResult::NoMatch => format!(
                 "doesn't contain key {:?} or contains key {:?}, which value {}",
                 self.key,
                 self.key,
                 self.inner.describe(MatcherResult::NoMatch)
-            ),
+            )
+            .into(),
         }
     }
 }

--- a/googletest/src/matchers/is_encoded_string_matcher.rs
+++ b/googletest/src/matchers/is_encoded_string_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a byte sequence which is a UTF-8 encoded string matched by `inner`.
@@ -72,23 +75,27 @@ where
             .unwrap_or(MatcherResult::NoMatch)
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => format!(
                 "is a UTF-8 encoded string which {}",
                 self.inner.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
             MatcherResult::NoMatch => format!(
                 "is not a UTF-8 encoded string which {}",
                 self.inner.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
         }
     }
 
-    fn explain_match(&self, actual: &Self::ActualT) -> String {
+    fn explain_match(&self, actual: &Self::ActualT) -> Description {
         match String::from_utf8(actual.as_ref().to_vec()) {
-            Ok(s) => format!("which is a UTF-8 encoded string {}", self.inner.explain_match(&s)),
-            Err(e) => format!("which is not a UTF-8 encoded string: {e}"),
+            Ok(s) => {
+                format!("which is a UTF-8 encoded string {}", self.inner.explain_match(&s)).into()
+            }
+            Err(e) => format!("which is not a UTF-8 encoded string: {e}").into(),
         }
     }
 }

--- a/googletest/src/matchers/is_encoded_string_matcher.rs
+++ b/googletest/src/matchers/is_encoded_string_matcher.rs
@@ -129,7 +129,7 @@ mod tests {
 
         verify_that!(
             matcher.describe(MatcherResult::Match),
-            eq("is a UTF-8 encoded string which is equal to \"A string\"")
+            displays_as(eq("is a UTF-8 encoded string which is equal to \"A string\""))
         )
     }
 
@@ -139,7 +139,7 @@ mod tests {
 
         verify_that!(
             matcher.describe(MatcherResult::NoMatch),
-            eq("is not a UTF-8 encoded string which is equal to \"A string\"")
+            displays_as(eq("is not a UTF-8 encoded string which is equal to \"A string\""))
         )
     }
 
@@ -149,7 +149,7 @@ mod tests {
 
         verify_that!(
             explanation,
-            eq("which is a UTF-8 encoded string which is equal to \"A string\"")
+            displays_as(eq("which is a UTF-8 encoded string which is equal to \"A string\""))
         )
     }
 
@@ -157,7 +157,7 @@ mod tests {
     fn has_correct_explanation_when_byte_array_is_not_utf8_encoded() -> Result<()> {
         let explanation = is_utf8_string(eq("A string")).explain_match(&&[192, 128, 0, 64]);
 
-        verify_that!(explanation, starts_with("which is not a UTF-8 encoded string: "))
+        verify_that!(explanation, displays_as(starts_with("which is not a UTF-8 encoded string: ")))
     }
 
     #[test]
@@ -167,7 +167,7 @@ mod tests {
 
         verify_that!(
             explanation,
-            eq("which is a UTF-8 encoded string which isn't equal to \"A string\"")
+            displays_as(eq("which is a UTF-8 encoded string which isn't equal to \"A string\""))
         )
     }
 }

--- a/googletest/src/matchers/is_matcher.rs
+++ b/googletest/src/matchers/is_matcher.rs
@@ -14,7 +14,10 @@
 
 #![doc(hidden)]
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches precisely values matched by `inner`.
@@ -44,22 +47,24 @@ impl<'a, ActualT: Debug, InnerMatcherT: Matcher<ActualT = ActualT>> Matcher
         self.inner.matches(actual)
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => format!(
                 "is {} which {}",
                 self.description,
                 self.inner.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
             MatcherResult::NoMatch => format!(
                 "is not {} which {}",
                 self.description,
                 self.inner.describe(MatcherResult::Match)
-            ),
+            )
+            .into(),
         }
     }
 
-    fn explain_match(&self, actual: &Self::ActualT) -> String {
+    fn explain_match(&self, actual: &Self::ActualT) -> Description {
         self.inner.explain_match(actual)
     }
 }

--- a/googletest/src/matchers/is_nan_matcher.rs
+++ b/googletest/src/matchers/is_nan_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use num_traits::float::Float;
 use std::{fmt::Debug, marker::PhantomData};
 
@@ -30,8 +33,8 @@ impl<T: Float + Debug> Matcher for IsNanMatcher<T> {
         actual.is_nan().into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
-        if matcher_result.into() { "is NaN" } else { "isn't NaN" }.to_string()
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
+        if matcher_result.into() { "is NaN" } else { "isn't NaN" }.into()
     }
 }
 

--- a/googletest/src/matchers/le_matcher.rs
+++ b/googletest/src/matchers/le_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value less than or equal to (in the sense of `<=`) `expected`.
@@ -91,10 +94,10 @@ impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
         (*actual <= self.expected).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is less than or equal to {:?}", self.expected),
-            MatcherResult::NoMatch => format!("is greater than {:?}", self.expected),
+            MatcherResult::Match => format!("is less than or equal to {:?}", self.expected).into(),
+            MatcherResult::NoMatch => format!("is greater than {:?}", self.expected).into(),
         }
     }
 }

--- a/googletest/src/matchers/len_matcher.rs
+++ b/googletest/src/matchers/len_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use crate::matcher_support::count_elements::count_elements;
 use std::{fmt::Debug, marker::PhantomData};
@@ -70,26 +71,29 @@ where
         self.expected.matches(&count_elements(actual))
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
-                format!("has length, which {}", self.expected.describe(MatcherResult::Match))
+                format!("has length, which {}", self.expected.describe(MatcherResult::Match)).into()
             }
             MatcherResult::NoMatch => {
                 format!("has length, which {}", self.expected.describe(MatcherResult::NoMatch))
+                    .into()
             }
         }
     }
 
-    fn explain_match(&self, actual: &T) -> String {
+    fn explain_match(&self, actual: &T) -> Description {
         let actual_size = count_elements(actual);
         format!("which has length {}, {}", actual_size, self.expected.explain_match(&actual_size))
+            .into()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::len;
+    use crate::description::Description;
     use crate::matcher::{Matcher, MatcherResult};
     use crate::prelude::*;
     use indoc::indoc;
@@ -182,11 +186,11 @@ mod tests {
                 false.into()
             }
 
-            fn describe(&self, _: MatcherResult) -> String {
+            fn describe(&self, _: MatcherResult) -> Description {
                 "called described".into()
             }
 
-            fn explain_match(&self, _: &T) -> String {
+            fn explain_match(&self, _: &T) -> Description {
                 "called explain_match".into()
             }
         }

--- a/googletest/src/matchers/lt_matcher.rs
+++ b/googletest/src/matchers/lt_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a value less (in the sense of `<`) than `expected`.
@@ -91,11 +94,11 @@ impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
         (*actual < self.expected).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is less than {:?}", self.expected),
+            MatcherResult::Match => format!("is less than {:?}", self.expected).into(),
             MatcherResult::NoMatch => {
-                format!("is greater than or equal to {:?}", self.expected)
+                format!("is greater than or equal to {:?}", self.expected).into()
             }
         }
     }

--- a/googletest/src/matchers/matches_regex_matcher.rs
+++ b/googletest/src/matchers/matches_regex_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use regex::Regex;
 use std::fmt::Debug;
@@ -94,13 +95,13 @@ where
         self.regex.is_match(actual.as_ref()).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
-                format!("matches the regular expression {:#?}", self.pattern.deref())
+                format!("matches the regular expression {:#?}", self.pattern.deref()).into()
             }
             MatcherResult::NoMatch => {
-                format!("doesn't match the regular expression {:#?}", self.pattern.deref())
+                format!("doesn't match the regular expression {:#?}", self.pattern.deref()).into()
             }
         }
     }

--- a/googletest/src/matchers/matches_regex_matcher.rs
+++ b/googletest/src/matchers/matches_regex_matcher.rs
@@ -204,7 +204,7 @@ mod tests {
 
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("matches the regular expression \"\\n\"")
+            displays_as(eq("matches the regular expression \"\\n\""))
         )
     }
 }

--- a/googletest/src/matchers/near_matcher.rs
+++ b/googletest/src/matchers/near_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use num_traits::{Float, FloatConst};
 use std::fmt::Debug;
 
@@ -179,13 +182,13 @@ impl<T: Debug + Float> Matcher for NearMatcher<T> {
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
-                format!("is within {:?} of {:?}", self.max_abs_error, self.expected)
+                format!("is within {:?} of {:?}", self.max_abs_error, self.expected).into()
             }
             MatcherResult::NoMatch => {
-                format!("isn't within {:?} of {:?}", self.max_abs_error, self.expected)
+                format!("isn't within {:?} of {:?}", self.max_abs_error, self.expected).into()
             }
         }
     }

--- a/googletest/src/matchers/none_matcher.rs
+++ b/googletest/src/matchers/none_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -46,10 +47,10 @@ impl<T: Debug> Matcher for NoneMatcher<T> {
         (actual.is_none()).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => "is none".to_string(),
-            MatcherResult::NoMatch => "is some(_)".to_string(),
+            MatcherResult::Match => "is none".into(),
+            MatcherResult::NoMatch => "is some(_)".into(),
         }
     }
 }

--- a/googletest/src/matchers/not_matcher.rs
+++ b/googletest/src/matchers/not_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches the actual value exactly when the inner matcher does _not_ match.
@@ -51,11 +54,11 @@ impl<T: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher for NotMatcher<T, In
         }
     }
 
-    fn explain_match(&self, actual: &T) -> String {
+    fn explain_match(&self, actual: &T) -> Description {
         self.inner.explain_match(actual)
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         self.inner.describe(if matcher_result.into() {
             MatcherResult::NoMatch
         } else {

--- a/googletest/src/matchers/ok_matcher.rs
+++ b/googletest/src/matchers/ok_matcher.rs
@@ -61,7 +61,9 @@ impl<T: Debug, E: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher
 
     fn explain_match(&self, actual: &Self::ActualT) -> Description {
         match actual {
-            Ok(o) => format!("which is a success {}", self.inner.explain_match(o)).into(),
+            Ok(o) => {
+                Description::new().text("which is a success").nested(self.inner.explain_match(o))
+            }
             Err(_) => "which is an error".into(),
         }
     }
@@ -130,7 +132,8 @@ mod tests {
                     Value of: Ok::<i32, i32>(1)
                     Expected: is a success containing a value, which is equal to 2
                     Actual: Ok(1),
-                      which is a success which isn't equal to 2
+                      which is a success
+                        which isn't equal to 2
                 "
             ))))
         )

--- a/googletest/src/matchers/ok_matcher.rs
+++ b/googletest/src/matchers/ok_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a `Result` containing `Ok` with a value matched by `inner`.
@@ -56,27 +59,25 @@ impl<T: Debug, E: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher
         actual.as_ref().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::NoMatch)
     }
 
-    fn explain_match(&self, actual: &Self::ActualT) -> String {
+    fn explain_match(&self, actual: &Self::ActualT) -> Description {
         match actual {
-            Ok(o) => format!("which is a success {}", self.inner.explain_match(o)),
-            Err(_) => "which is an error".to_string(),
+            Ok(o) => format!("which is a success {}", self.inner.explain_match(o)).into(),
+            Err(_) => "which is an error".into(),
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => {
-                format!(
-                    "is a success containing a value, which {}",
-                    self.inner.describe(MatcherResult::Match)
-                )
-            }
-            MatcherResult::NoMatch => {
-                format!(
-                    "is an error or a success containing a value, which {}",
-                    self.inner.describe(MatcherResult::NoMatch)
-                )
-            }
+            MatcherResult::Match => format!(
+                "is a success containing a value, which {}",
+                self.inner.describe(MatcherResult::Match)
+            )
+            .into(),
+            MatcherResult::NoMatch => format!(
+                "is an error or a success containing a value, which {}",
+                self.inner.describe(MatcherResult::NoMatch)
+            )
+            .into(),
         }
     }
 }

--- a/googletest/src/matchers/ok_matcher.rs
+++ b/googletest/src/matchers/ok_matcher.rs
@@ -144,7 +144,7 @@ mod tests {
         };
         verify_that!(
             matcher.describe(MatcherResult::Match),
-            eq("is a success containing a value, which is equal to 1")
+            displays_as(eq("is a success containing a value, which is equal to 1"))
         )
     }
 }

--- a/googletest/src/matchers/points_to_matcher.rs
+++ b/googletest/src/matchers/points_to_matcher.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::description::Description;
 use crate::matcher::{Matcher, MatcherResult};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -59,11 +60,11 @@ where
         self.expected.matches(actual.deref())
     }
 
-    fn explain_match(&self, actual: &ActualT) -> String {
+    fn explain_match(&self, actual: &ActualT) -> Description {
         self.expected.explain_match(actual.deref())
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         self.expected.describe(matcher_result)
     }
 }

--- a/googletest/src/matchers/pointwise_matcher.rs
+++ b/googletest/src/matchers/pointwise_matcher.rs
@@ -192,7 +192,7 @@ pub mod internal {
             }
         }
 
-        fn explain_match(&self, actual: &ContainerT) -> String {
+        fn explain_match(&self, actual: &ContainerT) -> Description {
             // TODO(b/260819741) This code duplicates elements_are_matcher.rs. Consider
             // extract as a separate library. (or implement pointwise! with
             // elements_are)
@@ -206,23 +206,24 @@ pub mod internal {
             }
             if mismatches.is_empty() {
                 if !zipped_iterator.has_size_mismatch() {
-                    "which matches all elements".to_string()
+                    "which matches all elements".into()
                 } else {
                     format!(
                         "which has size {} (expected {})",
                         zipped_iterator.left_size(),
                         self.matchers.len()
                     )
+                    .into()
                 }
             } else if mismatches.len() == 1 {
-                format!("where {}", mismatches[0])
+                format!("where {}", mismatches[0]).into()
             } else {
                 let mismatches = mismatches.into_iter().collect::<Description>();
-                format!("where:\n{}", mismatches.bullet_list().indent())
+                format!("where:\n{}", mismatches.bullet_list().indent()).into()
             }
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             format!(
                 "{} elements satisfying respectively:\n{}",
                 if matcher_result.into() { "has" } else { "doesn't have" },
@@ -233,6 +234,7 @@ pub mod internal {
                     .enumerate()
                     .indent()
             )
+            .into()
         }
     }
 }

--- a/googletest/src/matchers/pointwise_matcher.rs
+++ b/googletest/src/matchers/pointwise_matcher.rs
@@ -151,8 +151,8 @@ macro_rules! __pointwise {
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
 pub mod internal {
+    use crate::description::Description;
     use crate::matcher::{Matcher, MatcherResult};
-    use crate::matcher_support::description::Description;
     use crate::matcher_support::zipped_iterator::zip;
     use std::{fmt::Debug, marker::PhantomData};
 

--- a/googletest/src/matchers/predicate_matcher.rs
+++ b/googletest/src/matchers/predicate_matcher.rs
@@ -100,13 +100,13 @@ pub trait PredicateDescription {
 
 impl PredicateDescription for &str {
     fn to_description(&self) -> Description {
-        (*self).into()
+        self.to_string().into()
     }
 }
 
 impl PredicateDescription for String {
     fn to_description(&self) -> Description {
-        self.into()
+        self.to_string().into()
     }
 }
 

--- a/googletest/src/matchers/predicate_matcher.rs
+++ b/googletest/src/matchers/predicate_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Creates a matcher based on the predicate provided.
@@ -92,18 +95,18 @@ pub struct PredicateMatcher<T: ?Sized, P, D1, D2> {
 ///
 /// See [`PredicateMatcher::with_description`]
 pub trait PredicateDescription {
-    fn to_description(&self) -> String;
+    fn to_description(&self) -> Description;
 }
 
 impl PredicateDescription for &str {
-    fn to_description(&self) -> String {
-        self.to_string()
+    fn to_description(&self) -> Description {
+        (*self).into()
     }
 }
 
 impl PredicateDescription for String {
-    fn to_description(&self) -> String {
-        self.clone()
+    fn to_description(&self) -> Description {
+        self.into()
     }
 }
 
@@ -112,8 +115,8 @@ where
     T: Fn() -> S,
     S: Into<String>,
 {
-    fn to_description(&self) -> String {
-        self().into()
+    fn to_description(&self) -> Description {
+        self().into().into()
     }
 }
 
@@ -131,10 +134,10 @@ where
         (self.predicate)(actual).into()
     }
 
-    fn describe(&self, result: MatcherResult) -> String {
+    fn describe(&self, result: MatcherResult) -> Description {
         match result {
-            MatcherResult::Match => "matches".to_string(),
-            MatcherResult::NoMatch => "does not match".to_string(),
+            MatcherResult::Match => "matches".into(),
+            MatcherResult::NoMatch => "does not match".into(),
         }
     }
 }
@@ -150,7 +153,7 @@ where
         (self.predicate)(actual).into()
     }
 
-    fn describe(&self, result: MatcherResult) -> String {
+    fn describe(&self, result: MatcherResult) -> Description {
         match result {
             MatcherResult::Match => self.positive_description.to_description(),
             MatcherResult::NoMatch => self.negative_description.to_description(),

--- a/googletest/src/matchers/property_matcher.rs
+++ b/googletest/src/matchers/property_matcher.rs
@@ -134,7 +134,10 @@ macro_rules! property_internal {
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
 pub mod internal {
-    use crate::matcher::{Matcher, MatcherResult};
+    use crate::{
+        description::Description,
+        matcher::{Matcher, MatcherResult},
+    };
     use std::{fmt::Debug, marker::PhantomData};
 
     /// **For internal use only. API stablility is not guaranteed!**
@@ -167,15 +170,16 @@ pub mod internal {
             self.inner.matches(&(self.extractor)(actual))
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             format!(
                 "has property `{}`, which {}",
                 self.property_desc,
                 self.inner.describe(matcher_result)
             )
+            .into()
         }
 
-        fn explain_match(&self, actual: &OuterT) -> String {
+        fn explain_match(&self, actual: &OuterT) -> Description {
             let actual_inner = (self.extractor)(actual);
             format!(
                 "whose property `{}` is `{:#?}`, {}",
@@ -183,6 +187,7 @@ pub mod internal {
                 actual_inner,
                 self.inner.explain_match(&actual_inner)
             )
+            .into()
         }
     }
 
@@ -216,15 +221,16 @@ pub mod internal {
             self.inner.matches((self.extractor)(actual))
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             format!(
                 "has property `{}`, which {}",
                 self.property_desc,
                 self.inner.describe(matcher_result)
             )
+            .into()
         }
 
-        fn explain_match(&self, actual: &OuterT) -> String {
+        fn explain_match(&self, actual: &OuterT) -> Description {
             let actual_inner = (self.extractor)(actual);
             format!(
                 "whose property `{}` is `{:#?}`, {}",
@@ -232,6 +238,7 @@ pub mod internal {
                 actual_inner,
                 self.inner.explain_match(actual_inner)
             )
+            .into()
         }
     }
 }

--- a/googletest/src/matchers/some_matcher.rs
+++ b/googletest/src/matchers/some_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches an `Option` containing a value matched by `inner`.
@@ -51,24 +54,23 @@ impl<T: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher for SomeMatcher<T, I
         actual.as_ref().map(|v| self.inner.matches(v)).unwrap_or(MatcherResult::NoMatch)
     }
 
-    fn explain_match(&self, actual: &Option<T>) -> String {
+    fn explain_match(&self, actual: &Option<T>) -> Description {
         match (self.matches(actual), actual) {
-            (_, Some(t)) => format!("which has a value {}", self.inner.explain_match(t)),
-            (_, None) => "which is None".to_string(),
+            (_, Some(t)) => format!("which has a value {}", self.inner.explain_match(t)).into(),
+            (_, None) => "which is None".into(),
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
             MatcherResult::Match => {
-                format!("has a value which {}", self.inner.describe(MatcherResult::Match))
+                format!("has a value which {}", self.inner.describe(MatcherResult::Match)).into()
             }
-            MatcherResult::NoMatch => {
-                format!(
-                    "is None or has a value which {}",
-                    self.inner.describe(MatcherResult::NoMatch)
-                )
-            }
+            MatcherResult::NoMatch => format!(
+                "is None or has a value which {}",
+                self.inner.describe(MatcherResult::NoMatch)
+            )
+            .into(),
         }
     }
 }

--- a/googletest/src/matchers/some_matcher.rs
+++ b/googletest/src/matchers/some_matcher.rs
@@ -127,7 +127,7 @@ mod tests {
     fn some_describe_matches() -> Result<()> {
         verify_that!(
             some(eq(1)).describe(MatcherResult::Match),
-            eq("has a value which is equal to 1")
+            displays_as(eq("has a value which is equal to 1"))
         )
     }
 
@@ -135,7 +135,7 @@ mod tests {
     fn some_describe_does_not_match() -> Result<()> {
         verify_that!(
             some(eq(1)).describe(MatcherResult::NoMatch),
-            eq("is None or has a value which isn't equal to 1")
+            displays_as(eq("is None or has a value which isn't equal to 1"))
         )
     }
 

--- a/googletest/src/matchers/some_matcher.rs
+++ b/googletest/src/matchers/some_matcher.rs
@@ -56,7 +56,9 @@ impl<T: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher for SomeMatcher<T, I
 
     fn explain_match(&self, actual: &Option<T>) -> Description {
         match (self.matches(actual), actual) {
-            (_, Some(t)) => format!("which has a value {}", self.inner.explain_match(t)).into(),
+            (_, Some(t)) => {
+                Description::new().text("which has a value").nested(self.inner.explain_match(t))
+            }
             (_, None) => "which is None".into(),
         }
     }
@@ -119,7 +121,8 @@ mod tests {
                     Value of: Some(2)
                     Expected: has a value which is equal to 1
                     Actual: Some(2),
-                      which has a value which isn't equal to 1
+                      which has a value
+                        which isn't equal to 1
                 "
             ))))
         )
@@ -150,7 +153,7 @@ mod tests {
     fn some_explain_match_with_some_success() -> Result<()> {
         verify_that!(
             some(eq(1)).explain_match(&Some(1)),
-            displays_as(eq("which has a value which is equal to 1"))
+            displays_as(eq("which has a value\n  which is equal to 1"))
         )
     }
 
@@ -158,7 +161,7 @@ mod tests {
     fn some_explain_match_with_some_fail() -> Result<()> {
         verify_that!(
             some(eq(1)).explain_match(&Some(2)),
-            displays_as(eq("which has a value which isn't equal to 1"))
+            displays_as(eq("which has a value\n  which isn't equal to 1"))
         )
     }
 }

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{
+    description::Description,
     matcher::{Matcher, MatcherResult},
     matcher_support::{
         edit_distance,
@@ -303,11 +304,11 @@ where
         self.configuration.do_strings_match(self.expected.deref(), actual.as_ref()).into()
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         self.configuration.describe(matcher_result, self.expected.deref())
     }
 
-    fn explain_match(&self, actual: &ActualT) -> String {
+    fn explain_match(&self, actual: &ActualT) -> Description {
         self.configuration.explain_match(self.expected.deref(), actual.as_ref())
     }
 }
@@ -467,7 +468,7 @@ impl Configuration {
     }
 
     // StrMatcher::describe redirects immediately to this function.
-    fn describe(&self, matcher_result: MatcherResult, expected: &str) -> String {
+    fn describe(&self, matcher_result: MatcherResult, expected: &str) -> Description {
         let mut addenda: Vec<Cow<'static, str>> = Vec::with_capacity(3);
         match (self.ignore_leading_whitespace, self.ignore_trailing_whitespace) {
             (true, true) => addenda.push("ignoring leading and trailing whitespace".into()),
@@ -502,14 +503,15 @@ impl Configuration {
                 MatcherResult::NoMatch => "does not end with",
             },
         };
-        format!("{match_mode_description} {expected:?}{extra}")
+        format!("{match_mode_description} {expected:?}{extra}").into()
     }
 
-    fn explain_match(&self, expected: &str, actual: &str) -> String {
+    fn explain_match(&self, expected: &str, actual: &str) -> Description {
         let default_explanation = format!(
             "which {}",
             self.describe(self.do_strings_match(expected, actual).into(), expected)
-        );
+        )
+        .into();
         if !expected.contains('\n') || !actual.contains('\n') {
             return default_explanation;
         }
@@ -549,7 +551,7 @@ impl Configuration {
             MatchMode::EndsWith => create_diff_reversed(actual, expected, self.mode.to_diff_mode()),
         };
 
-        format!("{default_explanation}\n{diff}")
+        format!("{default_explanation}\n{diff}").into()
     }
 
     fn ignoring_leading_whitespace(self) -> Self {

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -549,7 +549,7 @@ impl Configuration {
             MatchMode::EndsWith => create_diff_reversed(actual, expected, self.mode.to_diff_mode()),
         };
 
-        format!("{default_explanation}\n{diff}",)
+        format!("{default_explanation}\n{diff}")
     }
 
     fn ignoring_leading_whitespace(self) -> Self {
@@ -726,8 +726,8 @@ mod tests {
     }
 
     #[test]
-    fn matches_string_containing_expected_value_in_contains_mode_while_ignoring_ascii_case()
-    -> Result<()> {
+    fn matches_string_containing_expected_value_in_contains_mode_while_ignoring_ascii_case(
+    ) -> Result<()> {
         verify_that!("Some string", contains_substring("STR").ignoring_ascii_case())
     }
 
@@ -811,7 +811,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string");
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("is equal to \"A string\"")
+            displays_as(eq("is equal to \"A string\""))
         )
     }
 
@@ -820,7 +820,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string");
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::NoMatch),
-            eq("isn't equal to \"A string\"")
+            displays_as(eq("isn't equal to \"A string\""))
         )
     }
 
@@ -830,7 +830,7 @@ mod tests {
             StrMatcher::with_default_config("A string").ignoring_leading_whitespace();
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("is equal to \"A string\" (ignoring leading whitespace)")
+            displays_as(eq("is equal to \"A string\" (ignoring leading whitespace)"))
         )
     }
 
@@ -840,7 +840,7 @@ mod tests {
             StrMatcher::with_default_config("A string").ignoring_leading_whitespace();
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::NoMatch),
-            eq("isn't equal to \"A string\" (ignoring leading whitespace)")
+            displays_as(eq("isn't equal to \"A string\" (ignoring leading whitespace)"))
         )
     }
 
@@ -850,7 +850,7 @@ mod tests {
             StrMatcher::with_default_config("A string").ignoring_trailing_whitespace();
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("is equal to \"A string\" (ignoring trailing whitespace)")
+            displays_as(eq("is equal to \"A string\" (ignoring trailing whitespace)"))
         )
     }
 
@@ -861,7 +861,7 @@ mod tests {
             StrMatcher::with_default_config("A string").ignoring_outer_whitespace();
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("is equal to \"A string\" (ignoring leading and trailing whitespace)")
+            displays_as(eq("is equal to \"A string\" (ignoring leading and trailing whitespace)"))
         )
     }
 
@@ -871,19 +871,21 @@ mod tests {
             StrMatcher::with_default_config("A string").ignoring_ascii_case();
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("is equal to \"A string\" (ignoring ASCII case)")
+            displays_as(eq("is equal to \"A string\" (ignoring ASCII case)"))
         )
     }
 
     #[test]
-    fn describes_itself_for_matching_result_ignoring_ascii_case_and_leading_whitespace()
-    -> Result<()> {
+    fn describes_itself_for_matching_result_ignoring_ascii_case_and_leading_whitespace(
+    ) -> Result<()> {
         let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string")
             .ignoring_leading_whitespace()
             .ignoring_ascii_case();
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("is equal to \"A string\" (ignoring leading whitespace, ignoring ASCII case)")
+            displays_as(eq(
+                "is equal to \"A string\" (ignoring leading whitespace, ignoring ASCII case)"
+            ))
         )
     }
 
@@ -892,7 +894,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = contains_substring("A string");
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("contains a substring \"A string\"")
+            displays_as(eq("contains a substring \"A string\""))
         )
     }
 
@@ -901,7 +903,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = contains_substring("A string");
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::NoMatch),
-            eq("does not contain a substring \"A string\"")
+            displays_as(eq("does not contain a substring \"A string\""))
         )
     }
 
@@ -910,7 +912,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = contains_substring("A string").times(gt(2));
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("contains a substring \"A string\" (count is greater than 2)")
+            displays_as(eq("contains a substring \"A string\" (count is greater than 2)"))
         )
     }
 
@@ -919,7 +921,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = starts_with("A string");
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("starts with prefix \"A string\"")
+            displays_as(eq("starts with prefix \"A string\""))
         )
     }
 
@@ -928,7 +930,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = starts_with("A string");
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::NoMatch),
-            eq("does not start with \"A string\"")
+            displays_as(eq("does not start with \"A string\""))
         )
     }
 
@@ -937,7 +939,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = ends_with("A string");
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq("ends with suffix \"A string\"")
+            displays_as(eq("ends with suffix \"A string\""))
         )
     }
 
@@ -946,7 +948,7 @@ mod tests {
         let matcher: StrMatcher<&str, _> = ends_with("A string");
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::NoMatch),
-            eq("does not end with \"A string\"")
+            displays_as(eq("does not end with \"A string\""))
         )
     }
 
@@ -971,14 +973,13 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(contains_substring(indoc!(
-                "
-                 First line
-                -Second line
-                +Second lines
-                 Third line
-                "
-            ))))
+            err(displays_as(contains_substring(
+                "\
+   First line
+  -Second line
+  +Second lines
+   Third line"
+            )))
         )
     }
 
@@ -1004,21 +1005,20 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(contains_substring(indoc!(
+            err(displays_as(contains_substring(
                 "
-                     First line
-                    -Second line
-                    +Second lines
-                     Third line
-                     <---- remaining lines omitted ---->
-                "
-            ))))
+   First line
+  -Second line
+  +Second lines
+   Third line
+   <---- remaining lines omitted ---->"
+            )))
         )
     }
 
     #[test]
-    fn match_explanation_for_starts_with_includes_both_versions_of_differing_last_line()
-    -> Result<()> {
+    fn match_explanation_for_starts_with_includes_both_versions_of_differing_last_line(
+    ) -> Result<()> {
         let result = verify_that!(
             indoc!(
                 "
@@ -1037,14 +1037,13 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(contains_substring(indoc!(
-                "
-                     First line
-                    -Second line
-                    +Second lines
-                     <---- remaining lines omitted ---->
-                "
-            ))))
+            err(displays_as(contains_substring(
+                "\
+   First line
+  -Second line
+  +Second lines
+   <---- remaining lines omitted ---->"
+            )))
         )
     }
 
@@ -1070,16 +1069,15 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(contains_substring(indoc!(
+            err(displays_as(contains_substring(
                 "
-                    Difference(-actual / +expected):
-                     <---- remaining lines omitted ---->
-                     Second line
-                    +Third lines
-                    -Third line
-                     Fourth line
-                "
-            ))))
+Difference(-actual / +expected):
+ <---- remaining lines omitted ---->
+ Second line
++Third lines
+-Third line
+ Fourth line"
+            )))
         )
     }
 
@@ -1107,22 +1105,22 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(contains_substring(indoc!(
-                "
-                    Difference(-actual / +expected):
-                     <---- remaining lines omitted ---->
-                     Second line
-                    +Third lines
-                    -Third line
-                     Fourth line
-                     <---- remaining lines omitted ---->"
-            ))))
+            err(displays_as(contains_substring(
+                "\
+  Difference(-actual / +expected):
+   <---- remaining lines omitted ---->
+   Second line
+  +Third lines
+  -Third line
+   Fourth line
+   <---- remaining lines omitted ---->"
+            )))
         )
     }
 
     #[test]
-    fn match_explanation_for_contains_substring_shows_diff_when_first_and_last_line_are_incomplete()
-    -> Result<()> {
+    fn match_explanation_for_contains_substring_shows_diff_when_first_and_last_line_are_incomplete(
+    ) -> Result<()> {
         let result = verify_that!(
             indoc!(
                 "
@@ -1144,20 +1142,19 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(contains_substring(indoc!(
-                "
-                    Difference(-actual / +expected):
-                     <---- remaining lines omitted ---->
-                    +line
-                    -Second line
-                     Third line
-                    +Foorth line
-                    -Fourth line
-                    +Fifth
-                    -Fifth line
-                     <---- remaining lines omitted ---->
-                "
-            ))))
+            err(displays_as(contains_substring(
+                "\
+  Difference(-actual / +expected):
+   <---- remaining lines omitted ---->
+  +line
+  -Second line
+   Third line
+  +Foorth line
+  -Fourth line
+  +Fifth
+  -Fifth line
+   <---- remaining lines omitted ---->"
+            )))
         )
     }
 
@@ -1183,15 +1180,14 @@ mod tests {
 
         verify_that!(
             result,
-            err(displays_as(contains_substring(indoc!(
-                "
-                     First line
-                    -Second line
-                    +Second lines
-                     Third line
-                    -Fourth line
-                "
-            ))))
+            err(displays_as(contains_substring(
+                "\
+   First line
+  -Second line
+  +Second lines
+   Third line
+  -Fourth line"
+            )))
         )
     }
 

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -1073,12 +1073,12 @@ mod tests {
             result,
             err(displays_as(contains_substring(
                 "
-Difference(-actual / +expected):
- <---- remaining lines omitted ---->
- Second line
-+Third lines
--Third line
- Fourth line"
+  Difference(-actual / +expected):
+   <---- remaining lines omitted ---->
+   Second line
+  +Third lines
+  -Third line
+   Fourth line"
             )))
         )
     }

--- a/googletest/src/matchers/subset_of_matcher.rs
+++ b/googletest/src/matchers/subset_of_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a container all of whose items are in the given container
@@ -112,7 +115,7 @@ where
         MatcherResult::Match
     }
 
-    fn explain_match(&self, actual: &ActualT) -> String {
+    fn explain_match(&self, actual: &ActualT) -> Description {
         let unexpected_elements = actual
             .into_iter()
             .enumerate()
@@ -121,16 +124,16 @@ where
             .collect::<Vec<_>>();
 
         match unexpected_elements.len() {
-            0 => "which no element is unexpected".to_string(),
-            1 => format!("whose element {} is unexpected", &unexpected_elements[0]),
-            _ => format!("whose elements {} are unexpected", unexpected_elements.join(", ")),
+            0 => "which no element is unexpected".into(),
+            1 => format!("whose element {} is unexpected", &unexpected_elements[0]).into(),
+            _ => format!("whose elements {} are unexpected", unexpected_elements.join(", ")).into(),
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is a subset of {:#?}", self.superset),
-            MatcherResult::NoMatch => format!("isn't a subset of {:#?}", self.superset),
+            MatcherResult::Match => format!("is a subset of {:#?}", self.superset).into(),
+            MatcherResult::NoMatch => format!("isn't a subset of {:#?}", self.superset).into(),
         }
     }
 }

--- a/googletest/src/matchers/superset_of_matcher.rs
+++ b/googletest/src/matchers/superset_of_matcher.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::matcher::{Matcher, MatcherResult};
+use crate::{
+    description::Description,
+    matcher::{Matcher, MatcherResult},
+};
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Matches a container containing all of the items in the given container
@@ -113,7 +116,7 @@ where
         MatcherResult::Match
     }
 
-    fn explain_match(&self, actual: &ActualT) -> String {
+    fn explain_match(&self, actual: &ActualT) -> Description {
         let missing_items: Vec<_> = self
             .subset
             .into_iter()
@@ -121,16 +124,16 @@ where
             .map(|expected_item| format!("{expected_item:#?}"))
             .collect();
         match missing_items.len() {
-            0 => "whose no element is missing".to_string(),
-            1 => format!("whose element {} is missing", &missing_items[0]),
-            _ => format!("whose elements {} are missing", missing_items.join(", ")),
+            0 => "whose no element is missing".into(),
+            1 => format!("whose element {} is missing", &missing_items[0]).into(),
+            _ => format!("whose elements {} are missing", missing_items.join(", ")).into(),
         }
     }
 
-    fn describe(&self, matcher_result: MatcherResult) -> String {
+    fn describe(&self, matcher_result: MatcherResult) -> Description {
         match matcher_result {
-            MatcherResult::Match => format!("is a superset of {:#?}", self.subset),
-            MatcherResult::NoMatch => format!("isn't a superset of {:#?}", self.subset),
+            MatcherResult::Match => format!("is a superset of {:#?}", self.subset).into(),
+            MatcherResult::NoMatch => format!("isn't a superset of {:#?}", self.subset).into(),
         }
     }
 }

--- a/googletest/src/matchers/tuple_matcher.rs
+++ b/googletest/src/matchers/tuple_matcher.rs
@@ -25,21 +25,7 @@ pub mod internal {
         description::Description,
         matcher::{Matcher, MatcherResult},
     };
-    use std::fmt::{Debug, Write};
-
-    /// Replaces the first expression with the second at compile time.
-    ///
-    /// This is used below in repetition sequences where the output must only
-    /// include the same expression repeated the same number of times as the
-    /// macro input.
-    ///
-    /// **For internal use only. API stablility is not guaranteed!**
-    #[doc(hidden)]
-    macro_rules! replace_expr {
-        ($_ignored:tt, $replacement:expr) => {
-            $replacement
-        };
-    }
+    use std::fmt::Debug;
 
     // This implementation is provided for completeness, but is completely trivial.
     // The only actual value which can be supplied is (), which must match.
@@ -80,40 +66,29 @@ pub mod internal {
                 }
 
                 fn explain_match(&self, actual: &($($field_type,)*)) -> Description {
-                    let mut explanation = format!("which {}", self.describe(self.matches(actual)));
+                    let mut explanation = Description::new().text("which").nested(self.describe(self.matches(actual)));
                     $(match self.$field_number.matches(&actual.$field_number) {
                         MatcherResult::Match => {},
                         MatcherResult::NoMatch => {
-                            writeln!(
-                                &mut explanation,
-                                concat!("Element #", $field_number, " is {:?}, {}"),
-                                actual.$field_number,
-                                self.$field_number.explain_match(&actual.$field_number)
-                            ).unwrap();
+                            explanation = explanation
+                                .text(format!(concat!("Element #", $field_number, " is {:?},"), actual.$field_number))
+                                .nested(self.$field_number.explain_match(&actual.$field_number));
                         }
                     })*
-                    (explanation.into())
+                    explanation
                 }
 
                 fn describe(&self, matcher_result: MatcherResult) -> Description {
                     match matcher_result {
                         MatcherResult::Match => {
-                            format!(
-                                concat!(
-                                    "is a tuple whose values respectively match:\n",
-                                    $(replace_expr!($field_number, "  {},\n")),*
-                                ),
-                                $(self.$field_number.describe(matcher_result)),*
-                            ).into()
+                            let mut description = Description::new().text("is a tuple whose values respectively match:");
+                            $(description = description.nested(self.$field_number.describe(matcher_result));)*
+                            description
                         }
                         MatcherResult::NoMatch => {
-                            format!(
-                                concat!(
-                                    "is a tuple whose values do not respectively match:\n",
-                                    $(replace_expr!($field_number, "  {},\n")),*
-                                ),
-                                $(self.$field_number.describe(MatcherResult::Match)),*
-                            ).into()
+                            let mut description = Description::new().text("is a tuple whose values do not respectively match:");
+                            $(description = description.nested(self.$field_number.describe(MatcherResult::Match));)*
+                            description
                         }
                     }
                 }

--- a/googletest/src/matchers/tuple_matcher.rs
+++ b/googletest/src/matchers/tuple_matcher.rs
@@ -21,7 +21,10 @@
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
 pub mod internal {
-    use crate::matcher::{Matcher, MatcherResult};
+    use crate::{
+        description::Description,
+        matcher::{Matcher, MatcherResult},
+    };
     use std::fmt::{Debug, Write};
 
     /// Replaces the first expression with the second at compile time.
@@ -47,7 +50,7 @@ pub mod internal {
             MatcherResult::Match
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             match matcher_result {
                 MatcherResult::Match => "is the empty tuple".into(),
                 MatcherResult::NoMatch => "is not the empty tuple".into(),
@@ -76,7 +79,7 @@ pub mod internal {
                     MatcherResult::Match
                 }
 
-                fn explain_match(&self, actual: &($($field_type,)*)) -> String {
+                fn explain_match(&self, actual: &($($field_type,)*)) -> Description {
                     let mut explanation = format!("which {}", self.describe(self.matches(actual)));
                     $(match self.$field_number.matches(&actual.$field_number) {
                         MatcherResult::Match => {},
@@ -89,10 +92,10 @@ pub mod internal {
                             ).unwrap();
                         }
                     })*
-                    (explanation)
+                    (explanation.into())
                 }
 
-                fn describe(&self, matcher_result: MatcherResult) -> String {
+                fn describe(&self, matcher_result: MatcherResult) -> Description {
                     match matcher_result {
                         MatcherResult::Match => {
                             format!(
@@ -101,7 +104,7 @@ pub mod internal {
                                     $(replace_expr!($field_number, "  {},\n")),*
                                 ),
                                 $(self.$field_number.describe(matcher_result)),*
-                            )
+                            ).into()
                         }
                         MatcherResult::NoMatch => {
                             format!(
@@ -110,7 +113,7 @@ pub mod internal {
                                     $(replace_expr!($field_number, "  {},\n")),*
                                 ),
                                 $(self.$field_number.describe(MatcherResult::Match)),*
-                            )
+                            ).into()
                         }
                     }
                 }

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -415,7 +415,7 @@ pub mod internal {
             match_matrix.is_match_for(self.requirements).into()
         }
 
-        fn explain_match(&self, actual: &ContainerT) -> String {
+        fn explain_match(&self, actual: &ContainerT) -> Description {
             if let Some(size_mismatch_explanation) =
                 self.requirements.explain_size_mismatch(actual, N)
             {
@@ -432,10 +432,10 @@ pub mod internal {
             let best_match = match_matrix.find_best_match();
             best_match
                 .get_explanation(actual, &self.elements, self.requirements)
-                .unwrap_or("whose elements all match".to_string())
+                .unwrap_or("whose elements all match".into())
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             format!(
                 "{} elements matching in any order:\n{}",
                 if matcher_result.into() { "contains" } else { "doesn't contain" },
@@ -446,6 +446,7 @@ pub mod internal {
                     .enumerate()
                     .indent()
             )
+            .into()
         }
     }
 
@@ -491,7 +492,7 @@ pub mod internal {
             match_matrix.is_match_for(self.requirements).into()
         }
 
-        fn explain_match(&self, actual: &ContainerT) -> String {
+        fn explain_match(&self, actual: &ContainerT) -> Description {
             if let Some(size_mismatch_explanation) =
                 self.requirements.explain_size_mismatch(actual, N)
             {
@@ -509,10 +510,10 @@ pub mod internal {
 
             best_match
                 .get_explanation_for_map(actual, &self.elements, self.requirements)
-                .unwrap_or("whose elements all match".to_string())
+                .unwrap_or("whose elements all match".into())
         }
 
-        fn describe(&self, matcher_result: MatcherResult) -> String {
+        fn describe(&self, matcher_result: MatcherResult) -> Description {
             format!(
                 "{} elements matching in any order:\n{}",
                 if matcher_result.into() { "contains" } else { "doesn't contain" },
@@ -526,6 +527,7 @@ pub mod internal {
                     .collect::<Description>()
                     .indent()
             )
+            .into()
         }
     }
 
@@ -554,25 +556,25 @@ pub mod internal {
             &self,
             actual: &ContainerT,
             expected_size: usize,
-        ) -> Option<String>
+        ) -> Option<Description>
         where
             for<'b> &'b ContainerT: IntoIterator,
         {
             let actual_size = count_elements(actual);
             match self {
-                Requirements::PerfectMatch if actual_size != expected_size => {
-                    Some(format!("which has size {} (expected {})", actual_size, expected_size))
-                }
+                Requirements::PerfectMatch if actual_size != expected_size => Some(
+                    format!("which has size {} (expected {})", actual_size, expected_size).into(),
+                ),
 
-                Requirements::Superset if actual_size < expected_size => Some(format!(
-                    "which has size {} (expected at least {})",
-                    actual_size, expected_size
-                )),
+                Requirements::Superset if actual_size < expected_size => Some(
+                    format!("which has size {} (expected at least {})", actual_size, expected_size)
+                        .into(),
+                ),
 
-                Requirements::Subset if actual_size > expected_size => Some(format!(
-                    "which has size {} (expected at most {})",
-                    actual_size, expected_size
-                )),
+                Requirements::Subset if actual_size > expected_size => Some(
+                    format!("which has size {} (expected at most {})", actual_size, expected_size)
+                        .into(),
+                ),
 
                 _ => None,
             }
@@ -650,7 +652,7 @@ pub mod internal {
             }
         }
 
-        fn explain_unmatchable(&self, requirements: Requirements) -> Option<String> {
+        fn explain_unmatchable(&self, requirements: Requirements) -> Option<Description> {
             let unmatchable_elements = match requirements {
                 Requirements::PerfectMatch => self.find_unmatchable_elements(),
                 Requirements::Superset => self.find_unmatched_expected(),
@@ -857,7 +859,7 @@ pub mod internal {
                 || self.unmatchable_expected.iter().any(|b| *b)
         }
 
-        fn get_explanation(&self) -> Option<String> {
+        fn get_explanation(&self) -> Option<Description> {
             let unmatchable_actual = self.unmatchable_actual();
             let actual_idx = unmatchable_actual
                 .iter()
@@ -873,29 +875,29 @@ pub mod internal {
             match (unmatchable_actual.len(), unmatchable_expected.len()) {
                 (0, 0) => None,
                 (1, 0) => {
-                    Some(format!("whose element {actual_idx} does not match any expected elements"))
+                    Some(format!("whose element {actual_idx} does not match any expected elements").into())
                 }
                 (_, 0) => {
-                    Some(format!("whose elements {actual_idx} do not match any expected elements",))
+                    Some(format!("whose elements {actual_idx} do not match any expected elements",).into())
                 }
                 (0, 1) => Some(format!(
                     "which has no element matching the expected element {expected_idx}"
-                )),
+                ).into()),
                 (0, _) => Some(format!(
                     "which has no elements matching the expected elements {expected_idx}"
-                )),
+                ).into()),
                 (1, 1) => Some(format!(
                     "whose element {actual_idx} does not match any expected elements and no elements match the expected element {expected_idx}"
-                )),
+                ).into()),
                 (_, 1) => Some(format!(
                     "whose elements {actual_idx} do not match any expected elements and no elements match the expected element {expected_idx}"
-                )),
+                ).into()),
                 (1, _) => Some(format!(
                     "whose element {actual_idx} does not match any expected elements and no elements match the expected elements {expected_idx}"
-                )),
+                ).into()),
                 (_, _) => Some(format!(
                     "whose elements {actual_idx} do not match any expected elements and no elements match the expected elements {expected_idx}"
-                )),
+                ).into()),
             }
         }
 
@@ -962,7 +964,7 @@ pub mod internal {
             actual: &ContainerT,
             expected: &[Box<dyn Matcher<ActualT = T> + 'a>; N],
             requirements: Requirements,
-        ) -> Option<String>
+        ) -> Option<Description>
         where
             for<'b> &'b ContainerT: IntoIterator<Item = &'b T>,
         {
@@ -1001,7 +1003,7 @@ pub mod internal {
                 .indent();
             Some(format!(
                 "which does not have a {requirements} match with the expected elements. The best match found was:\n{best_match}"
-            ))
+            ).into())
         }
 
         fn get_explanation_for_map<'a, KeyT: Debug, ValueT: Debug, ContainerT: Debug + ?Sized>(
@@ -1009,7 +1011,7 @@ pub mod internal {
             actual: &ContainerT,
             expected: &[KeyValueMatcher<'a, KeyT, ValueT>; N],
             requirements: Requirements,
-        ) -> Option<String>
+        ) -> Option<Description>
         where
             for<'b> &'b ContainerT: IntoIterator<Item = (&'b KeyT, &'b ValueT)>,
         {
@@ -1059,7 +1061,7 @@ pub mod internal {
                 .indent();
             Some(format!(
                 "which does not have a {requirements} match with the expected elements. The best match found was:\n{best_match}"
-            ))
+            ).into())
         }
     }
 }

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -365,9 +365,9 @@ macro_rules! __is_contained_in {
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
 pub mod internal {
+    use crate::description::Description;
     use crate::matcher::{Matcher, MatcherResult};
     use crate::matcher_support::count_elements::count_elements;
-    use crate::matcher_support::description::Description;
     use std::collections::HashSet;
     use std::fmt::{Debug, Display};
     use std::marker::PhantomData;

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -1081,19 +1081,19 @@ mod tests {
         // aren't dropped too early.
         let matchers = ((eq(2), eq("Two")), (eq(1), eq("One")), (eq(3), eq("Three")));
         let matcher: UnorderedElementsOfMapAreMatcher<HashMap<i32, &str>, _, _, 3> = unordered_elements_are![
-            (matchers.0.0, matchers.0.1),
-            (matchers.1.0, matchers.1.1),
-            (matchers.2.0, matchers.2.1)
+            (matchers.0 .0, matchers.0 .1),
+            (matchers.1 .0, matchers.1 .1),
+            (matchers.2 .0, matchers.2 .1)
         ];
         verify_that!(
             Matcher::describe(&matcher, MatcherResult::Match),
-            eq(indoc!(
+            displays_as(eq(indoc!(
                 "
                 contains elements matching in any order:
                   is equal to 2 => is equal to \"Two\"
                   is equal to 1 => is equal to \"One\"
                   is equal to 3 => is equal to \"Three\""
-            ))
+            )))
         )
     }
 
@@ -1106,9 +1106,9 @@ mod tests {
         // aren't dropped too early.
         let matchers = ((anything(), eq(1)), (anything(), eq(2)), (anything(), eq(2)));
         let matcher: UnorderedElementsOfMapAreMatcher<HashMap<u32, u32>, _, _, 3> = unordered_elements_are![
-            (matchers.0.0, matchers.0.1),
-            (matchers.1.0, matchers.1.1),
-            (matchers.2.0, matchers.2.1),
+            (matchers.0 .0, matchers.0 .1),
+            (matchers.1 .0, matchers.1 .1),
+            (matchers.2 .0, matchers.2 .1),
         ];
         let value: HashMap<u32, u32> = HashMap::from_iter([(0, 1), (1, 1), (2, 2)]);
         verify_that!(

--- a/googletest/tests/all_matcher_test.rs
+++ b/googletest/tests/all_matcher_test.rs
@@ -89,3 +89,67 @@ fn all_multiple_failed_assertions() -> Result<()> {
         ))))
     )
 }
+
+#[test]
+fn formats_error_message_correctly_when_all_is_inside_some() -> Result<()> {
+    let value = Some(4);
+    let result = verify_that!(value, some(all![eq(1), eq(2), eq(3)]));
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc!(
+            "
+            Value of: value
+            Expected: has a value which has all the following properties:
+              * is equal to 1
+              * is equal to 2
+              * is equal to 3
+            Actual: Some(4),
+              which has a value
+                * which isn't equal to 1
+                * which isn't equal to 2
+                * which isn't equal to 3"
+        ))))
+    )
+}
+
+#[test]
+fn formats_error_message_correctly_when_all_is_inside_ok() -> Result<()> {
+    let value: std::result::Result<i32, std::io::Error> = Ok(4);
+    let result = verify_that!(value, ok(all![eq(1), eq(2), eq(3)]));
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc!(
+            "
+            Value of: value
+            Expected: is a success containing a value, which has all the following properties:
+              * is equal to 1
+              * is equal to 2
+              * is equal to 3
+            Actual: Ok(4),
+              which is a success
+                * which isn't equal to 1
+                * which isn't equal to 2
+                * which isn't equal to 3"
+        ))))
+    )
+}
+
+#[test]
+fn formats_error_message_correctly_when_all_is_inside_err() -> Result<()> {
+    let value: std::result::Result<(), &'static str> = Err("An error");
+    let result = verify_that!(value, err(all![starts_with("Not"), ends_with("problem")]));
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc!(
+            r#"
+            Value of: value
+            Expected: is an error which has all the following properties:
+              * starts with prefix "Not"
+              * ends with suffix "problem"
+            Actual: Err("An error"),
+              which is an error
+                * which does not start with "Not"
+                * which does not end with "problem""#
+        ))))
+    )
+}

--- a/googletest/tests/all_matcher_test.rs
+++ b/googletest/tests/all_matcher_test.rs
@@ -61,9 +61,7 @@ fn admits_matchers_without_static_lifetime() -> Result<()> {
 fn mismatch_description_two_failed_matchers() -> Result<()> {
     verify_that!(
         all!(starts_with("One"), starts_with("Two")).explain_match("Three"),
-        displays_as(eq(
-            "* which does not start with \"One\"\n  * which does not start with \"Two\""
-        ))
+        displays_as(eq("* which does not start with \"One\"\n* which does not start with \"Two\""))
     )
 }
 

--- a/googletest/tests/any_matcher_test.rs
+++ b/googletest/tests/any_matcher_test.rs
@@ -61,9 +61,7 @@ fn admits_matchers_without_static_lifetime() -> Result<()> {
 fn mismatch_description_two_failed_matchers() -> Result<()> {
     verify_that!(
         any!(starts_with("One"), starts_with("Two")).explain_match("Three"),
-        displays_as(eq(
-            "* which does not start with \"One\"\n  * which does not start with \"Two\""
-        ))
+        displays_as(eq("* which does not start with \"One\"\n* which does not start with \"Two\""))
     )
 }
 

--- a/googletest/tests/any_matcher_test.rs
+++ b/googletest/tests/any_matcher_test.rs
@@ -89,3 +89,67 @@ fn all_multiple_failed_assertions() -> Result<()> {
         ))))
     )
 }
+
+#[test]
+fn formats_error_message_correctly_when_any_is_inside_some() -> Result<()> {
+    let value = Some(4);
+    let result = verify_that!(value, some(any![eq(1), eq(2), eq(3)]));
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc!(
+            "
+            Value of: value
+            Expected: has a value which has at least one of the following properties:
+              * is equal to 1
+              * is equal to 2
+              * is equal to 3
+            Actual: Some(4),
+              which has a value
+                * which isn't equal to 1
+                * which isn't equal to 2
+                * which isn't equal to 3"
+        ))))
+    )
+}
+
+#[test]
+fn formats_error_message_correctly_when_any_is_inside_ok() -> Result<()> {
+    let value: std::result::Result<i32, std::io::Error> = Ok(4);
+    let result = verify_that!(value, ok(any![eq(1), eq(2), eq(3)]));
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc!(
+            "
+            Value of: value
+            Expected: is a success containing a value, which has at least one of the following properties:
+              * is equal to 1
+              * is equal to 2
+              * is equal to 3
+            Actual: Ok(4),
+              which is a success
+                * which isn't equal to 1
+                * which isn't equal to 2
+                * which isn't equal to 3"
+        ))))
+    )
+}
+
+#[test]
+fn formats_error_message_correctly_when_any_is_inside_err() -> Result<()> {
+    let value: std::result::Result<(), &'static str> = Err("An error");
+    let result = verify_that!(value, err(any![starts_with("Not"), ends_with("problem")]));
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(indoc!(
+            r#"
+            Value of: value
+            Expected: is an error which has at least one of the following properties:
+              * starts with prefix "Not"
+              * ends with suffix "problem"
+            Actual: Err("An error"),
+              which is an error
+                * which does not start with "Not"
+                * which does not end with "problem""#
+        ))))
+    )
+}

--- a/googletest/tests/colorized_diff_test.rs
+++ b/googletest/tests/colorized_diff_test.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use googletest::prelude::*;
-use indoc::indoc;
 use std::fmt::{Display, Write};
 
 // Make a long text with each element of the iterator on one line.
@@ -37,16 +36,15 @@ fn colors_appear_when_no_color_is_no_set_and_force_color_is_set() -> Result<()> 
 
     verify_that!(
         result,
-        err(displays_as(contains_substring(indoc! {
+        err(displays_as(contains_substring(
             "
-
-            Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
-             1
-             2
-             \x1B[3m<---- 45 common lines omitted ---->\x1B[0m
-             48
-             49
-            +\x1B[1;32m50\x1B[0m"
-        })))
+  Difference(-\x1B[1;31mactual\x1B[0m / +\x1B[1;32mexpected\x1B[0m):
+   1
+   2
+   \x1B[3m<---- 45 common lines omitted ---->\x1B[0m
+   48
+   49
+  +\x1B[1;32m50\x1B[0m"
+        )))
     )
 }

--- a/googletest/tests/elements_are_matcher_test.rs
+++ b/googletest/tests/elements_are_matcher_test.rs
@@ -91,12 +91,12 @@ fn elements_are_produces_correct_failure_message_nested() -> Result<()> {
                        1. is equal to 3
                 Actual: [[0, 1], [1, 2]],
                   where:
-                  * element #0 is [0, 1], where:
-                      * element #0 is 0, which isn't equal to 1
-                      * element #1 is 1, which isn't equal to 2
-                  * element #1 is [1, 2], where:
-                      * element #0 is 1, which isn't equal to 2
-                      * element #1 is 2, which isn't equal to 3"
+                    * element #0 is [0, 1], where:
+                        * element #0 is 0, which isn't equal to 1
+                        * element #1 is 1, which isn't equal to 2
+                    * element #1 is [1, 2], where:
+                        * element #0 is 1, which isn't equal to 2
+                        * element #1 is 2, which isn't equal to 3"
         ))))
     )
 }

--- a/googletest/tests/field_matcher_test.rs
+++ b/googletest/tests/field_matcher_test.rs
@@ -41,7 +41,7 @@ fn field_error_message_shows_field_name_and_inner_matcher() -> Result<()> {
 
     verify_that!(
         matcher.describe(MatcherResult::Match),
-        eq("has field `int`, which is equal to 31")
+        displays_as(eq("has field `int`, which is equal to 31"))
     )
 }
 

--- a/googletest/tests/pointwise_matcher_test.rs
+++ b/googletest/tests/pointwise_matcher_test.rs
@@ -127,8 +127,8 @@ fn pointwise_returns_mismatch_when_actual_value_does_not_match_on_second_item() 
 }
 
 #[test]
-fn pointwise_returns_mismatch_when_actual_value_does_not_match_on_first_and_second_items()
--> Result<()> {
+fn pointwise_returns_mismatch_when_actual_value_does_not_match_on_first_and_second_items(
+) -> Result<()> {
     let result = verify_that!(vec![1, 2, 3], pointwise!(eq, vec![2, 3, 3]));
 
     verify_that!(
@@ -142,8 +142,8 @@ fn pointwise_returns_mismatch_when_actual_value_does_not_match_on_first_and_seco
               2. is equal to 3
             Actual: [1, 2, 3],
               where:
-              * element #0 is 1, which isn't equal to 2
-              * element #1 is 2, which isn't equal to 3"
+                * element #0 is 1, which isn't equal to 2
+                * element #1 is 2, which isn't equal to 3"
         ))))
     )
 }

--- a/googletest/tests/property_matcher_test.rs
+++ b/googletest/tests/property_matcher_test.rs
@@ -122,7 +122,7 @@ fn does_not_match_struct_with_non_matching_property() -> Result<()> {
 fn describes_itself_in_matching_case() -> Result<()> {
     verify_that!(
         property!(SomeStruct.get_property(), eq(1)).describe(MatcherResult::Match),
-        eq("has property `get_property()`, which is equal to 1")
+        displays_as(eq("has property `get_property()`, which is equal to 1"))
     )
 }
 
@@ -130,7 +130,7 @@ fn describes_itself_in_matching_case() -> Result<()> {
 fn describes_itself_in_not_matching_case() -> Result<()> {
     verify_that!(
         property!(SomeStruct.get_property(), eq(1)).describe(MatcherResult::NoMatch),
-        eq("has property `get_property()`, which isn't equal to 1")
+        displays_as(eq("has property `get_property()`, which isn't equal to 1"))
     )
 }
 
@@ -156,7 +156,7 @@ fn explains_mismatch_referencing_explanation_of_inner_matcher() -> Result<()> {
 fn describes_itself_in_matching_case_for_ref() -> Result<()> {
     verify_that!(
         property!(*SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::Match),
-        eq("has property `get_property_ref()`, which is equal to 1")
+        displays_as(eq("has property `get_property_ref()`, which is equal to 1"))
     )
 }
 
@@ -164,7 +164,7 @@ fn describes_itself_in_matching_case_for_ref() -> Result<()> {
 fn describes_itself_in_not_matching_case_for_ref() -> Result<()> {
     verify_that!(
         property!(*SomeStruct.get_property_ref(), eq(1)).describe(MatcherResult::NoMatch),
-        eq("has property `get_property_ref()`, which isn't equal to 1")
+        displays_as(eq("has property `get_property_ref()`, which isn't equal to 1"))
     )
 }
 

--- a/googletest/tests/tuple_matcher_test.rs
+++ b/googletest/tests/tuple_matcher_test.rs
@@ -180,8 +180,7 @@ fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
         displays_as(eq(indoc!(
             "
             is a tuple whose values respectively match:
-              is equal to 1,
-            "
+              is equal to 1"
         )))
     )
 }
@@ -193,8 +192,7 @@ fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
         displays_as(eq(indoc!(
             "
             is a tuple whose values do not respectively match:
-              is equal to 1,
-            "
+              is equal to 1"
         )))
     )
 }
@@ -206,9 +204,8 @@ fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
         displays_as(eq(indoc!(
             "
             is a tuple whose values respectively match:
-              is equal to 1,
-              is equal to 2,
-            "
+              is equal to 1
+              is equal to 2"
         )))
     )
 }
@@ -220,9 +217,8 @@ fn tuple_matcher_2_has_correct_description_for_mismatch() -> Result<()> {
         displays_as(eq(indoc!(
             "
             is a tuple whose values do not respectively match:
-              is equal to 1,
-              is equal to 2,
-            "
+              is equal to 1
+              is equal to 2"
         )))
     )
 }
@@ -233,11 +229,12 @@ fn describe_match_shows_which_tuple_element_did_not_match() -> Result<()> {
         (eq(1), eq(2)).explain_match(&(1, 3)),
         displays_as(eq(indoc!(
             "
-            which is a tuple whose values do not respectively match:
-              is equal to 1,
-              is equal to 2,
-            Element #1 is 3, which isn't equal to 2
-            "
+            which
+              is a tuple whose values do not respectively match:
+                is equal to 1
+                is equal to 2
+            Element #1 is 3,
+              which isn't equal to 2"
         )))
     )
 }
@@ -248,12 +245,14 @@ fn describe_match_shows_which_two_tuple_elements_did_not_match() -> Result<()> {
         (eq(1), eq(2)).explain_match(&(2, 3)),
         displays_as(eq(indoc!(
             "
-            which is a tuple whose values do not respectively match:
-              is equal to 1,
-              is equal to 2,
-            Element #0 is 2, which isn't equal to 1
-            Element #1 is 3, which isn't equal to 2
-            "
+            which
+              is a tuple whose values do not respectively match:
+                is equal to 1
+                is equal to 2
+            Element #0 is 2,
+              which isn't equal to 1
+            Element #1 is 3,
+              which isn't equal to 2"
         )))
     )
 }

--- a/googletest/tests/tuple_matcher_test.rs
+++ b/googletest/tests/tuple_matcher_test.rs
@@ -177,12 +177,12 @@ fn tuple_matcher_with_trailing_comma_matches_matching_12_tuple() -> Result<()> {
 fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
     verify_that!(
         (eq(1),).describe(MatcherResult::Match),
-        eq(indoc!(
+        displays_as(eq(indoc!(
             "
             is a tuple whose values respectively match:
               is equal to 1,
             "
-        ))
+        )))
     )
 }
 
@@ -190,12 +190,12 @@ fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
 fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
         (eq(1),).describe(MatcherResult::NoMatch),
-        eq(indoc!(
+        displays_as(eq(indoc!(
             "
             is a tuple whose values do not respectively match:
               is equal to 1,
             "
-        ))
+        )))
     )
 }
 
@@ -203,13 +203,13 @@ fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
 fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
     verify_that!(
         (eq(1), eq(2)).describe(MatcherResult::Match),
-        eq(indoc!(
+        displays_as(eq(indoc!(
             "
             is a tuple whose values respectively match:
               is equal to 1,
               is equal to 2,
             "
-        ))
+        )))
     )
 }
 
@@ -217,13 +217,13 @@ fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
 fn tuple_matcher_2_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
         (eq(1), eq(2)).describe(MatcherResult::NoMatch),
-        eq(indoc!(
+        displays_as(eq(indoc!(
             "
             is a tuple whose values do not respectively match:
               is equal to 1,
               is equal to 2,
             "
-        ))
+        )))
     )
 }
 

--- a/integration_tests/src/integration_tests.rs
+++ b/integration_tests/src/integration_tests.rs
@@ -170,7 +170,8 @@ mod tests {
                 Value of: Some(1)
                 Expected: has a value which is equal to 2
                 Actual: Some(1),
-                  which has a value which isn't equal to 2
+                  which has a value
+                    which isn't equal to 2
             "})
         );
         expect_that!(
@@ -179,7 +180,8 @@ mod tests {
                 Value of: value
                 Expected: is a success containing a value, which is equal to 2
                 Actual: Ok(1),
-                  which is a success which isn't equal to 2
+                  which is a success
+                    which isn't equal to 2
             "})
         );
         expect_that!(
@@ -188,7 +190,8 @@ mod tests {
                 Value of: value
                 Expected: is an error which is equal to 2
                 Actual: Err(1),
-                  which is an error which isn't equal to 2
+                  which is an error
+                    which isn't equal to 2
             "})
         );
         Ok(())


### PR DESCRIPTION
See https://github.com/google/googletest-rust/issues/325#issuecomment-1826423227.

This is a rather large PR, so I've split the steps into individual commits which are hopefully individually understandable. I wanted to present it as a whole so that it's clear what the whole plan is.

This does not replace all existing code for constructing descriptions and match explanations. It focuses just on the parts which I could see were broken. We can clean the rest up as we go along.

Fixes #325 