### PR TITLE
Support an extra failure message directly in `assert_that!` and `expect_that!`.

### DIFF
--- a/integration_tests/src/custom_error_message.rs
+++ b/integration_tests/src/custom_error_message.rs
@@ -36,4 +36,60 @@ mod tests {
         verify_that!(value, eq(3))
             .with_failure_message(|| "A custom error message from a closure".to_string())
     }
+
+    #[test]
+    fn should_include_failure_message_in_third_parameter_to_assert_that() {
+        let value = 2;
+        assert_that!(value, eq(3), "assert_that: A custom error message for value {value}");
+    }
+
+    #[test]
+    fn should_include_failure_message_in_third_parameter_with_format_arguments_to_assert_that() {
+        let value = 2;
+        assert_that!(
+            value,
+            eq(3),
+            "assert_that: A custom error message for incremented value {}",
+            value + 1
+        );
+    }
+
+    #[test]
+    fn should_accept_trailing_comma_after_format_arguments_in_assert_that() {
+        let value = 2;
+        assert_that!(
+            value,
+            eq(3),
+            "assert_that: A custom error message for twice incremented value {}",
+            value + 2,
+        );
+    }
+
+    #[googletest::test]
+    fn should_include_failure_message_in_third_parameter_to_expect_that() {
+        let value = 2;
+        expect_that!(value, eq(3), "expect_that: A custom error message for value {value}");
+    }
+
+    #[googletest::test]
+    fn should_include_failure_message_in_third_parameter_with_format_arguments_to_expect_that() {
+        let value = 2;
+        expect_that!(
+            value,
+            eq(3),
+            "expect_that: A custom error message for incremented value {}",
+            value + 1
+        );
+    }
+
+    #[googletest::test]
+    fn should_accept_trailing_comma_after_format_arguments_in_expect_that() {
+        let value = 2;
+        expect_that!(
+            value,
+            eq(3),
+            "expect_that: A custom error message for twice incremented value {}",
+            value + 2,
+        );
+    }
 }

--- a/integration_tests/src/integration_tests.rs
+++ b/integration_tests/src/integration_tests.rs
@@ -291,7 +291,31 @@ mod tests {
 
         verify_that!(output, contains_substring("A custom error message"))?;
         verify_that!(output, contains_substring("A custom error message in a String"))?;
-        verify_that!(output, contains_substring("A custom error message from a closure"))
+        verify_that!(output, contains_substring("A custom error message from a closure"))?;
+        verify_that!(
+            output,
+            contains_substring("assert_that: A custom error message for value 2")
+        )?;
+        verify_that!(
+            output,
+            contains_substring("assert_that: A custom error message for incremented value 3")
+        )?;
+        verify_that!(
+            output,
+            contains_substring("assert_that: A custom error message for twice incremented value 4")
+        )?;
+        verify_that!(
+            output,
+            contains_substring("expect_that: A custom error message for value 2")
+        )?;
+        verify_that!(
+            output,
+            contains_substring("expect_that: A custom error message for incremented value 3")
+        )?;
+        verify_that!(
+            output,
+            contains_substring("expect_that: A custom error message for twice incremented value 4")
+        )
     }
 
     #[test]


### PR DESCRIPTION
This adds optional additional parameters to `assert_that!` and `expect_that!` which, if present, are formatted via `format!` into a failure message in the event of an assertion failure. The formatting takes place only if the assertion fails. Otherwise, the extra arguments have no effect.

Fixes #331