### PR TITLE
Add support for trailing commas on `assert_that!` and `expect_that!`.

### DIFF
--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -136,7 +136,7 @@ macro_rules! verify_that {
             $crate::internal::source_location::SourceLocation::new(file!(), line!(), column!()),
         )
     };
-    ($actual:expr, $expected:expr) => {
+    ($actual:expr, $expected:expr $(,)?) => {
         $crate::assertions::internal::check_matcher(
             &$actual,
             $expected,
@@ -351,7 +351,7 @@ macro_rules! fail {
 /// equivalent to `ASSERT_THAT`, use [`verify_that!`] with the `?` operator.
 #[macro_export]
 macro_rules! assert_that {
-    ($actual:expr, $expected:expr) => {
+    ($actual:expr, $expected:expr $(,)?) => {
         match $crate::verify_that!($actual, $expected) {
             Ok(_) => {}
             Err(e) => {
@@ -442,7 +442,7 @@ macro_rules! assert_pred {
 /// ```
 #[macro_export]
 macro_rules! expect_that {
-    ($actual:expr, $expected:expr) => {{
+    ($actual:expr, $expected:expr $(,)?) => {{
         use $crate::GoogleTestSupport;
         $crate::verify_that!($actual, $expected).and_log_failure();
     }};

--- a/integration_tests/src/integration_tests.rs
+++ b/integration_tests/src/integration_tests.rs
@@ -27,6 +27,12 @@ mod tests {
     }
 
     #[test]
+    fn verify_that_supports_trailing_comma() -> Result<()> {
+        let value = 2;
+        verify_that!(value, eq(2),)
+    }
+
+    #[test]
     fn should_pass_with_omitted_elements_are() -> Result<()> {
         verify_that!(vec![1, 2], [eq(1), eq(2)])
     }
@@ -48,10 +54,21 @@ mod tests {
     }
 
     #[test]
-    fn should_pass_with_assert_that() -> Result<()> {
+    fn should_pass_with_assert_that() {
         let value = 2;
         assert_that!(value, eq(2));
-        Ok(())
+    }
+
+    #[test]
+    fn assert_that_supports_trailing_comma() {
+        let value = 2;
+        assert_that!(value, eq(2),);
+    }
+
+    #[test]
+    fn assert_that_with_custom_failure_message_supports_trailing_comma() {
+        let value = 2;
+        assert_that!(value, eq(2), "A custom error message",);
     }
 
     #[googletest::test]
@@ -65,6 +82,18 @@ mod tests {
     fn should_pass_with_expect_that_returning_unit() {
         let value = 2;
         expect_that!(value, eq(2));
+    }
+
+    #[googletest::test]
+    fn expect_that_supports_trailing_comma() {
+        let value = 2;
+        expect_that!(value, eq(2),);
+    }
+
+    #[googletest::test]
+    fn expect_that_with_custom_failure_message_supports_trailing_comma() {
+        let value = 2;
+        expect_that!(value, eq(2), "A custom error message",);
     }
 
     #[test]


### PR DESCRIPTION
Previously, putting a trailing comma on `assert_that!` or `expect_that!` would produce a compilation error when no custom error message is present:

```
assert_that!(
   value,
   eq(2),  // Error!
);
```

This change adds support for trailing commas, making the behaviour of these macros more consistent with the rest of the library and Rust idioms.

Fixes #340