### PR TITLE
Flip the PartialEq constraint on EqMatcher

### DIFF
--- a/googletest/src/matchers/contains_matcher.rs
+++ b/googletest/src/matchers/contains_matcher.rs
@@ -200,7 +200,7 @@ mod tests {
 
     #[test]
     fn contains_does_not_match_empty_slice() -> Result<()> {
-        let matcher = contains(eq(1));
+        let matcher = contains(eq::<i32, _>(1));
 
         let result = matcher.matches(&[]);
 

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -83,11 +83,11 @@ pub struct EqMatcher<A: ?Sized, T> {
     phantom: PhantomData<A>,
 }
 
-impl<A: Debug + ?Sized, T: PartialEq<A> + Debug> Matcher for EqMatcher<A, T> {
+impl<T: Debug, A: Debug + ?Sized + PartialEq<T>> Matcher for EqMatcher<A, T> {
     type ActualT = A;
 
     fn matches(&self, actual: &A) -> MatcherResult {
-        (self.expected == *actual).into()
+        (*actual == self.expected).into()
     }
 
     fn describe(&self, matcher_result: MatcherResult) -> Description {

--- a/googletest/src/matchers/some_matcher.rs
+++ b/googletest/src/matchers/some_matcher.rs
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn some_does_not_match_option_with_none() -> Result<()> {
-        let matcher = some(eq(1));
+        let matcher = some(eq::<i32, _>(1));
 
         let result = matcher.matches(&None);
 
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn some_describe_matches() -> Result<()> {
         verify_that!(
-            some(eq(1)).describe(MatcherResult::Match),
+            some(eq::<i32, _>(1)).describe(MatcherResult::Match),
             displays_as(eq("has a value which is equal to 1"))
         )
     }
@@ -139,14 +139,14 @@ mod tests {
     #[test]
     fn some_describe_does_not_match() -> Result<()> {
         verify_that!(
-            some(eq(1)).describe(MatcherResult::NoMatch),
+            some(eq::<i32, _>(1)).describe(MatcherResult::NoMatch),
             displays_as(eq("is None or has a value which isn't equal to 1"))
         )
     }
 
     #[test]
     fn some_explain_match_with_none() -> Result<()> {
-        verify_that!(some(eq(1)).explain_match(&None), displays_as(eq("which is None")))
+        verify_that!(some(eq::<i32, _>(1)).explain_match(&None), displays_as(eq("which is None")))
     }
 
     #[test]

--- a/googletest/tests/tuple_matcher_test.rs
+++ b/googletest/tests/tuple_matcher_test.rs
@@ -176,7 +176,7 @@ fn tuple_matcher_with_trailing_comma_matches_matching_12_tuple() -> Result<()> {
 #[test]
 fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
     verify_that!(
-        (eq(1),).describe(MatcherResult::Match),
+        (eq::<i32, _>(1),).describe(MatcherResult::Match),
         displays_as(eq(indoc!(
             "
             is a tuple whose values respectively match:
@@ -188,7 +188,7 @@ fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
 #[test]
 fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
-        (eq(1),).describe(MatcherResult::NoMatch),
+        (eq::<i32, _>(1),).describe(MatcherResult::NoMatch),
         displays_as(eq(indoc!(
             "
             is a tuple whose values do not respectively match:
@@ -200,7 +200,7 @@ fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
 #[test]
 fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
     verify_that!(
-        (eq(1), eq(2)).describe(MatcherResult::Match),
+        (eq::<i32, _>(1), eq::<i32, _>(2)).describe(MatcherResult::Match),
         displays_as(eq(indoc!(
             "
             is a tuple whose values respectively match:
@@ -213,7 +213,7 @@ fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
 #[test]
 fn tuple_matcher_2_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
-        (eq(1), eq(2)).describe(MatcherResult::NoMatch),
+        (eq::<i32, _>(1), eq::<i32, _>(2)).describe(MatcherResult::NoMatch),
         displays_as(eq(indoc!(
             "
             is a tuple whose values do not respectively match:

--- a/googletest/tests/unordered_elements_are_matcher_test.rs
+++ b/googletest/tests/unordered_elements_are_matcher_test.rs
@@ -352,7 +352,7 @@ fn is_contained_in_matches_hash_map_with_trailing_comma() -> Result<()> {
 
 #[test]
 fn is_contained_in_matches_when_container_is_empty() -> Result<()> {
-    verify_that!(vec![], is_contained_in!(eq(2), eq(3), eq(4)))
+    verify_that!(vec![], is_contained_in!(eq::<i32, _>(2), eq(3), eq(4)))
 }
 
 #[test]


### PR DESCRIPTION
This PR switch the `PartialEq` requirement in the `EqMatcher`. Instead of requiring `ExpectedT: PartialEq<ActualT>`, it will require `ActualT: PartialEq<ExpectedT>`. This change is normally not important as, most of the time, `ExpectedT == ActualT`, but it provides better ergonomy in the following case.


### Custom types comparable with canonical types

Libraries often need to implement a custom type representing the same data as a canonical type. For instance, `CustomI32` should be comparable with `i32`. The test could be written as:

```
#[test]
fn check() -> Result<()> {
  let actual: CustomI32 = compute();
  verify_that!(actual, eq(42))
}
```

But with the current definition, this require `i32: PartialEq<CustomI32>`, which cannot be implemented due to the orphan rule. However, with this change, implementing `CustomI32: PartialEq<i32>` is possible.


### Better compilation error

Consider:

```
#[test]
fn check() -> Result<()> {
  let actual: &str = "life, the universe and everything";
  verify_that!(actual, eq(42))
}
```

The compiler rejects the code with this error message:

```
error[E0277]: can't compare `{integer}` with `&str`
   --> googletest/src/matchers/eq_matcher.rs:416:30
    |
416 |         verify_that!(actual, eq(42))
    |                              ^^^^^^ no implementation for `{integer} == &str`
    |
   ::: googletest/src/assertions.rs:140:9
    |
140 |         $crate::assertions::internal::check_matcher(
    |         ------------------------------------------- required by a bound introduced by this call
    |
    = help: the trait `PartialEq<&str>` is not implemented for `{integer}`
    = help: the following other types implement trait `PartialEq<Rhs>`:
              <isize as PartialEq>
              <i8 as PartialEq>
              <i16 as PartialEq>
              <i32 as PartialEq>
              <i64 as PartialEq>
              <i128 as PartialEq>
              <usize as PartialEq>
              <u8 as PartialEq>
            and 10 others
```

which is not really useful. Most likely I need to change the value in `eq(...)` to be comparable to `actual` and not the other way around. With this PR, the error is:

```
error[E0277]: can't compare `&str` with `{integer}`
   --> googletest/src/matchers/eq_matcher.rs:416:30
    |
416 |         verify_that!(actual, eq(42))
    |                              ^^^^^^ no implementation for `&str == {integer}`
    |
   ::: googletest/src/assertions.rs:140:9
    |
140 |         $crate::assertions::internal::check_matcher(
    |         ------------------------------------------- required by a bound introduced by this call
    |
    = help: the trait `PartialEq<{integer}>` is not implemented for `&str`
    = help: the following other types implement trait `PartialEq<Rhs>`:
              <str as PartialEq<Cow<'a, str>>>
              <str as PartialEq<OsString>>
              <str as PartialEq<OsStr>>
              <str as PartialEq<String>>
              <str as PartialEq>
              <&'a str as PartialEq<OsString>>
              <&'a str as PartialEq<String>>
              <&'b str as PartialEq<Cow<'a, str>>>
```
which provide types that can be compared with `&str`.