### PR TITLE
Make Matcher::ActualT a generic parameter instead of an associated type

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,7 @@ struct MyEqMatcher<T> {
     expected: T,
 }
 
-impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
-    type ActualT = T;
-
+impl<T: PartialEq + Debug> Matcher<T> for MyEqMatcher<T> {
     fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
          (self.expected == *actual).into()
     }
@@ -179,7 +177,7 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
 It is recommended to expose a function which constructs the matcher:
 
 ```rust
-pub fn eq_my_way<T: PartialEq + Debug>(expected: T) -> impl Matcher<ActualT = T> {
+pub fn eq_my_way<T: PartialEq + Debug>(expected: T) -> impl Matcher<T> {
     MyEqMatcher { expected }
 }
 ```

--- a/googletest/crate_docs.md
+++ b/googletest/crate_docs.md
@@ -206,20 +206,19 @@ The following matchers are provided in GoogleTest Rust:
 
 One can extend the library by writing additional matchers. To do so, create
 a struct holding the matcher's data and have it implement the trait
-[`Matcher`]:
+[`Matcher`] (and optionally the [`MatcherExt`] trait):
 
 ```no_run
-use googletest::{description::Description, matcher::{Matcher, MatcherResult}};
+use googletest::{description::Description, matcher::{Matcher, MatcherExt, MatcherResult}};
 use std::fmt::Debug;
 
+#[derive(MatcherExt)]
 struct MyEqMatcher<T> {
     expected: T,
 }
 
-impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
-    type ActualT = T;
-
-    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
+impl<T: PartialEq + Debug> Matcher<T> for MyEqMatcher<T> {
+    fn matches(&self, actual: &T) -> MatcherResult {
         if self.expected == *actual {
             MatcherResult::Match
         } else {
@@ -243,17 +242,15 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
  It is recommended to expose a function which constructs the matcher:
 
  ```no_run
- # use googletest::{description::Description, matcher::{Matcher, MatcherResult}};
+ # use googletest::{description::Description, matcher::{Matcher, MatcherExt, MatcherResult}};
  # use std::fmt::Debug;
- #
+ # #[derive(MatcherExt)]
  # struct MyEqMatcher<T> {
  #    expected: T,
  # }
  #
- # impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
- #    type ActualT = T;
- #
- #    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
+ # impl<T: PartialEq + Debug> Matcher<T> for MyEqMatcher<T> {
+ #    fn matches(&self, actual: &T) -> MatcherResult {
  #        if self.expected == *actual {
  #            MatcherResult::Match
  #        } else {
@@ -273,7 +270,7 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
  #    }
  # }
  #
- pub fn eq_my_way<T: PartialEq + Debug>(expected: T) -> impl Matcher<ActualT = T> {
+ pub fn eq_my_way<T: PartialEq + Debug>(expected: T) -> impl Matcher<T> {
     MyEqMatcher { expected }
  }
  ```
@@ -282,17 +279,15 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
 
 ```
 # use googletest::prelude::*;
-# use googletest::{description::Description, matcher::{Matcher, MatcherResult}};
+# use googletest::{description::Description, matcher::{Matcher, MatcherExt, MatcherResult}};
 # use std::fmt::Debug;
-#
+# #[derive(MatcherExt)]
 # struct MyEqMatcher<T> {
 #    expected: T,
 # }
 #
-# impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
-#    type ActualT = T;
-#
-#    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
+# impl<T: PartialEq + Debug> Matcher<T> for MyEqMatcher<T> {
+#    fn matches(&self, actual: &T) -> MatcherResult {
 #        if self.expected == *actual {
 #            MatcherResult::Match
 #        } else {
@@ -312,7 +307,7 @@ impl<T: PartialEq + Debug> Matcher for MyEqMatcher<T> {
 #    }
 # }
 #
-# pub fn eq_my_way<T: PartialEq + Debug>(expected: T) -> impl Matcher<ActualT = T> {
+# pub fn eq_my_way<T: PartialEq + Debug>(expected: T) -> impl Matcher<T> {
 #    MyEqMatcher { expected }
 # }
 # /* The attribute macro would prevent the function from being compiled in a doctest.
@@ -493,3 +488,4 @@ through the `?` operator as the example above shows.
 [`and_log_failure()`]: GoogleTestSupport::and_log_failure
 [`into_test_result()`]: IntoTestResult::into_test_result
 [`Matcher`]: matcher::Matcher
+[`MatcherExt`]: matcher::MatcherExt

--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -499,7 +499,7 @@ pub mod internal {
     #[must_use = "The assertion result must be evaluated to affect the test result."]
     pub fn check_matcher<T: Debug + ?Sized>(
         actual: &T,
-        expected: impl Matcher<ActualT = T>,
+        expected: impl Matcher<T>,
         actual_expr: &'static str,
         source_location: SourceLocation,
     ) -> Result<(), TestAssertionFailure> {

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -42,7 +42,7 @@ pub mod matchers;
 /// }
 /// ```
 pub mod prelude {
-    pub use super::matcher::Matcher;
+    pub use super::matcher::{Matcher, MatcherExt};
     pub use super::matchers::*;
     pub use super::verify_current_test_outcome;
     pub use super::GoogleTestSupport;

--- a/googletest/src/matcher.rs
+++ b/googletest/src/matcher.rs
@@ -19,6 +19,7 @@ use crate::internal::source_location::SourceLocation;
 use crate::internal::test_outcome::TestAssertionFailure;
 use crate::matchers::__internal_unstable_do_not_depend_on_these::ConjunctionMatcher;
 use crate::matchers::__internal_unstable_do_not_depend_on_these::DisjunctionMatcher;
+pub use googletest_macro::MatcherExt;
 use std::fmt::Debug;
 
 /// An interface for checking an arbitrary condition on a datum.
@@ -26,17 +27,14 @@ use std::fmt::Debug;
 /// This trait is automatically implemented for a reference of any type
 /// implementing `Matcher`. This simplifies reusing a matcher in different
 /// assertions.
-pub trait Matcher {
-    /// The type against which this matcher matches.
-    type ActualT: Debug + ?Sized;
-
+pub trait Matcher<ActualT: Debug + ?Sized> {
     /// Returns whether the condition matches the datum `actual`.
     ///
     /// The trait implementation defines what it means to "match". Often the
     /// matching condition is based on data stored in the matcher. For example,
     /// `eq` matches when its stored expected value is equal (in the sense of
     /// the `==` operator) to the value `actual`.
-    fn matches(&self, actual: &Self::ActualT) -> MatcherResult;
+    fn matches(&self, actual: &ActualT) -> MatcherResult;
 
     /// Returns a description of `self` or a negative description if
     /// `matcher_result` is `DoesNotMatch`.
@@ -137,10 +135,22 @@ pub trait Matcher {
     ///         .nested(self.expected.explain_match(actual.deref()))
     /// }
     /// ```
-    fn explain_match(&self, actual: &Self::ActualT) -> Description {
+    fn explain_match(&self, actual: &ActualT) -> Description {
         format!("which {}", self.describe(self.matches(actual))).into()
     }
+}
 
+/// Trait extension for matchers. It is highly recommended to implement it for
+/// each type implementing `Matcher`.
+// The `and` and `or` functions cannot be part of the `Matcher` traits since it
+// is parametric. Consider that `and` and `or` are part of the `Matcher` trait
+// and `MyMatcher` implements both `Matcher<A>` and `Matcher<B>`.
+// Then `MyMatcher{...}.and(...)` can be either:
+//   * `Matcher::<A>::and(MyMatcher{...}, ...)` or
+//   * `Matcher::<B>::and(MyMatcher{...}, ...)`.
+// Moving the `and` and `or` functions in a non-generic trait remove this
+// confusion by making `and` and `or` unique for a given type.
+pub trait MatcherExt {
     /// Constructs a matcher that matches both `self` and `right`.
     ///
     /// ```
@@ -164,10 +174,7 @@ pub trait Matcher {
     // TODO(b/264518763): Replace the return type with impl Matcher and reduce
     // visibility of ConjunctionMatcher once impl in return position in trait
     // methods is stable.
-    fn and<Right: Matcher<ActualT = Self::ActualT>>(
-        self,
-        right: Right,
-    ) -> ConjunctionMatcher<Self, Right>
+    fn and<Right>(self, right: Right) -> ConjunctionMatcher<Self, Right>
     where
         Self: Sized,
     {
@@ -194,10 +201,7 @@ pub trait Matcher {
     // TODO(b/264518763): Replace the return type with impl Matcher and reduce
     // visibility of DisjunctionMatcher once impl in return position in trait
     // methods is stable.
-    fn or<Right: Matcher<ActualT = Self::ActualT>>(
-        self,
-        right: Right,
-    ) -> DisjunctionMatcher<Self, Right>
+    fn or<Right>(self, right: Right) -> DisjunctionMatcher<Self, Right>
     where
         Self: Sized,
     {
@@ -215,7 +219,7 @@ const PRETTY_PRINT_LENGTH_THRESHOLD: usize = 60;
 /// The parameter `actual_expr` contains the expression which was evaluated to
 /// obtain `actual`.
 pub(crate) fn create_assertion_failure<T: Debug + ?Sized>(
-    matcher: &impl Matcher<ActualT = T>,
+    matcher: &impl Matcher<T>,
     actual: &T,
     actual_expr: &'static str,
     source_location: SourceLocation,
@@ -273,10 +277,10 @@ impl MatcherResult {
     }
 }
 
-impl<M: Matcher> Matcher for &M {
-    type ActualT = M::ActualT;
+impl<M: ?Sized + MatcherExt> MatcherExt for &M {}
 
-    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
+impl<T: Debug + ?Sized, M: Matcher<T>> Matcher<T> for &M {
+    fn matches(&self, actual: &T) -> MatcherResult {
         (*self).matches(actual)
     }
 
@@ -284,7 +288,7 @@ impl<M: Matcher> Matcher for &M {
         (*self).describe(matcher_result)
     }
 
-    fn explain_match(&self, actual: &Self::ActualT) -> Description {
+    fn explain_match(&self, actual: &T) -> Description {
         (*self).explain_match(actual)
     }
 }

--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -38,7 +38,7 @@
 /// ```
 ///
 /// Using this macro is equivalent to using the
-/// [`and`][crate::matcher::Matcher::and] method:
+/// [`and`][crate::matcher::MatcherExt::and] method:
 ///
 /// ```
 /// # use googletest::prelude::*;
@@ -78,12 +78,12 @@ mod tests {
 
     #[test]
     fn description_shows_more_than_one_matcher() -> Result<()> {
-        let first_matcher: StrMatcher<String, _> = starts_with("A");
+        let first_matcher = starts_with("A");
         let second_matcher = ends_with("string");
         let matcher = all!(first_matcher, second_matcher);
 
         verify_that!(
-            matcher.describe(MatcherResult::Match),
+            Matcher::<String>::describe(&matcher, MatcherResult::Match),
             displays_as(eq(indoc!(
                 "
                 has all the following properties:
@@ -95,11 +95,11 @@ mod tests {
 
     #[test]
     fn description_shows_one_matcher_directly() -> Result<()> {
-        let first_matcher: StrMatcher<String, _> = starts_with("A");
+        let first_matcher = starts_with("A");
         let matcher = all!(first_matcher);
 
         verify_that!(
-            matcher.describe(MatcherResult::Match),
+            Matcher::<String>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("starts with prefix \"A\""))
         )
     }
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn mismatch_description_shows_which_matcher_failed_if_more_than_one_constituent() -> Result<()>
     {
-        let first_matcher: StrMatcher<str, _> = starts_with("Another");
+        let first_matcher = starts_with("Another");
         let second_matcher = ends_with("string");
         let matcher = all!(first_matcher, second_matcher);
 

--- a/googletest/src/matchers/any_matcher.rs
+++ b/googletest/src/matchers/any_matcher.rs
@@ -40,7 +40,7 @@
 /// ```
 ///
 /// Using this macro is equivalent to using the
-/// [`or`][crate::matcher::Matcher::or] method:
+/// [`or`][crate::matcher::MatcherExt::or] method:
 ///
 /// ```
 /// # use googletest::prelude::*;
@@ -80,12 +80,12 @@ mod tests {
 
     #[test]
     fn description_shows_more_than_one_matcher() -> Result<()> {
-        let first_matcher: StrMatcher<String, &str> = starts_with("A");
+        let first_matcher = starts_with("A");
         let second_matcher = ends_with("string");
         let matcher = any!(first_matcher, second_matcher);
 
         verify_that!(
-            matcher.describe(MatcherResult::Match),
+            Matcher::<String>::describe(&matcher, MatcherResult::Match),
             displays_as(eq(indoc!(
                 "
                 has at least one of the following properties:
@@ -97,11 +97,11 @@ mod tests {
 
     #[test]
     fn description_shows_one_matcher_directly() -> Result<()> {
-        let first_matcher: StrMatcher<String, &str> = starts_with("A");
+        let first_matcher = starts_with("A");
         let matcher = any!(first_matcher);
 
         verify_that!(
-            matcher.describe(MatcherResult::Match),
+            Matcher::<String>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("starts with prefix \"A\""))
         )
     }

--- a/googletest/src/matchers/anything_matcher.rs
+++ b/googletest/src/matchers/anything_matcher.rs
@@ -14,9 +14,9 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Matches anything. This matcher always succeeds.
 ///
@@ -32,15 +32,14 @@ use std::{fmt::Debug, marker::PhantomData};
 /// # }
 /// # should_pass().unwrap();
 /// ```
-pub fn anything<T: Debug + ?Sized>() -> impl Matcher<ActualT = T> {
-    Anything::<T>(Default::default())
+pub fn anything() -> Anything {
+    Anything
 }
 
-struct Anything<T: ?Sized>(PhantomData<T>);
+#[derive(MatcherExt)]
+pub struct Anything;
 
-impl<T: Debug + ?Sized> Matcher for Anything<T> {
-    type ActualT = T;
-
+impl<T: Debug + ?Sized> Matcher<T> for Anything {
     fn matches(&self, _: &T) -> MatcherResult {
         MatcherResult::Match
     }

--- a/googletest/src/matchers/conjunction_matcher.rs
+++ b/googletest/src/matchers/conjunction_matcher.rs
@@ -17,7 +17,7 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
 use std::fmt::Debug;
 
@@ -41,6 +41,7 @@ use std::fmt::Debug;
 ///
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
+#[derive(MatcherExt)]
 pub struct ConjunctionMatcher<M1, M2> {
     m1: M1,
     m2: M2,
@@ -52,20 +53,15 @@ impl<M1, M2> ConjunctionMatcher<M1, M2> {
     }
 }
 
-impl<M1: Matcher, M2: Matcher<ActualT = M1::ActualT>> Matcher for ConjunctionMatcher<M1, M2>
-where
-    M1::ActualT: Debug,
-{
-    type ActualT = M1::ActualT;
-
-    fn matches(&self, actual: &M1::ActualT) -> MatcherResult {
+impl<T: Debug + ?Sized, M1: Matcher<T>, M2: Matcher<T>> Matcher<T> for ConjunctionMatcher<M1, M2> {
+    fn matches(&self, actual: &T) -> MatcherResult {
         match (self.m1.matches(actual), self.m2.matches(actual)) {
             (MatcherResult::Match, MatcherResult::Match) => MatcherResult::Match,
             _ => MatcherResult::NoMatch,
         }
     }
 
-    fn explain_match(&self, actual: &M1::ActualT) -> Description {
+    fn explain_match(&self, actual: &T) -> Description {
         match (self.m1.matches(actual), self.m2.matches(actual)) {
             (MatcherResult::NoMatch, MatcherResult::Match) => self.m1.explain_match(actual),
             (MatcherResult::Match, MatcherResult::NoMatch) => self.m2.explain_match(actual),

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use crate::description::Description;
-use crate::matcher::{Matcher, MatcherResult};
+use crate::matcher::{Matcher, MatcherExt, MatcherResult};
 use std::fmt::{Debug, Display};
-use std::marker::PhantomData;
 
 /// Matches the string representation of types that implement `Display`.
 ///
@@ -23,22 +22,20 @@ use std::marker::PhantomData;
 /// let result: impl Display = ...;
 /// verify_that!(result, displays_as(eq(format!("{}", result))))?;
 /// ```
-pub fn displays_as<T: Debug + Display, InnerMatcher: Matcher<ActualT = String>>(
+pub fn displays_as<InnerMatcher: Matcher<String>>(
     inner: InnerMatcher,
-) -> impl Matcher<ActualT = T> {
-    DisplayMatcher::<T, _> { inner, phantom: Default::default() }
+) -> DisplayMatcher<InnerMatcher> {
+    DisplayMatcher { inner }
 }
 
-struct DisplayMatcher<T, InnerMatcher: Matcher> {
+#[derive(MatcherExt)]
+pub struct DisplayMatcher<InnerMatcher: Matcher<String>> {
     inner: InnerMatcher,
-    phantom: PhantomData<T>,
 }
 
-impl<T: Debug + Display, InnerMatcher: Matcher<ActualT = String>> Matcher
-    for DisplayMatcher<T, InnerMatcher>
+impl<T: Debug + Display, InnerMatcher: Matcher<String>> Matcher<T>
+    for DisplayMatcher<InnerMatcher>
 {
-    type ActualT = T;
-
     fn matches(&self, actual: &T) -> MatcherResult {
         self.inner.matches(&format!("{actual}"))
     }

--- a/googletest/src/matchers/empty_matcher.rs
+++ b/googletest/src/matchers/empty_matcher.rs
@@ -14,9 +14,9 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Matches an empty container.
 ///
@@ -50,23 +50,17 @@ use std::{fmt::Debug, marker::PhantomData};
 /// # should_pass().unwrap();
 /// ```
 
-pub fn empty<T: Debug + ?Sized>() -> impl Matcher<ActualT = T>
+pub fn empty() -> EmptyMatcher {
+    EmptyMatcher
+}
+
+#[derive(MatcherExt)]
+pub struct EmptyMatcher;
+
+impl<T: Debug + ?Sized> Matcher<T> for EmptyMatcher
 where
     for<'a> &'a T: IntoIterator,
 {
-    EmptyMatcher { phantom: Default::default() }
-}
-
-struct EmptyMatcher<T: ?Sized> {
-    phantom: PhantomData<T>,
-}
-
-impl<T: Debug + ?Sized> Matcher for EmptyMatcher<T>
-where
-    for<'a> &'a T: IntoIterator,
-{
-    type ActualT = T;
-
     fn matches(&self, actual: &T) -> MatcherResult {
         actual.into_iter().next().is_none().into()
     }

--- a/googletest/src/matchers/eq_deref_of_matcher.rs
+++ b/googletest/src/matchers/eq_deref_of_matcher.rs
@@ -14,10 +14,10 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
     matcher_support::{edit_distance, summarize_diff::create_diff},
 };
-use std::{fmt::Debug, marker::PhantomData, ops::Deref};
+use std::{fmt::Debug, ops::Deref};
 
 /// Matches a value equal (in the sense of `==`) to the dereferenced value of
 /// `expected`.
@@ -51,28 +51,24 @@ use std::{fmt::Debug, marker::PhantomData, ops::Deref};
 /// ```
 ///
 /// Otherwise, this has the same behaviour as [`eq`][crate::matchers::eq].
-pub fn eq_deref_of<ActualT: ?Sized, ExpectedRefT>(
-    expected: ExpectedRefT,
-) -> EqDerefOfMatcher<ActualT, ExpectedRefT> {
-    EqDerefOfMatcher { expected, phantom: Default::default() }
+pub fn eq_deref_of<ExpectedRefT>(expected: ExpectedRefT) -> EqDerefOfMatcher<ExpectedRefT> {
+    EqDerefOfMatcher { expected }
 }
 
 /// A matcher which matches a value equal to the derefenced value of `expected`.
 ///
 /// See [`eq_deref_of`].
-pub struct EqDerefOfMatcher<ActualT: ?Sized, ExpectedRefT> {
+#[derive(MatcherExt)]
+pub struct EqDerefOfMatcher<ExpectedRefT> {
     pub(crate) expected: ExpectedRefT,
-    phantom: PhantomData<ActualT>,
 }
 
-impl<ActualT, ExpectedRefT, ExpectedT> Matcher for EqDerefOfMatcher<ActualT, ExpectedRefT>
+impl<ActualT, ExpectedRefT, ExpectedT> Matcher<ActualT> for EqDerefOfMatcher<ExpectedRefT>
 where
     ActualT: Debug + ?Sized,
     ExpectedRefT: Deref<Target = ExpectedT> + Debug,
     ExpectedT: PartialEq<ActualT> + Debug,
 {
-    type ActualT = ActualT;
-
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         (self.expected.deref() == actual).into()
     }

--- a/googletest/src/matchers/ge_matcher.rs
+++ b/googletest/src/matchers/ge_matcher.rs
@@ -14,9 +14,9 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Matches a value greater than or equal to (in the sense of `>=`) `expected`.
 ///
@@ -74,22 +74,18 @@ use std::{fmt::Debug, marker::PhantomData};
 ///
 /// You can find the standard library `PartialOrd` implementation in
 /// <https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html#implementors>
-pub fn ge<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug>(
-    expected: ExpectedT,
-) -> impl Matcher<ActualT = ActualT> {
-    GeMatcher::<ActualT, _> { expected, phantom: Default::default() }
+pub fn ge<ExpectedT>(expected: ExpectedT) -> GeMatcher<ExpectedT> {
+    GeMatcher { expected }
 }
 
-struct GeMatcher<ActualT, ExpectedT> {
+#[derive(MatcherExt)]
+pub struct GeMatcher<ExpectedT> {
     expected: ExpectedT,
-    phantom: PhantomData<ActualT>,
 }
 
-impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
-    for GeMatcher<ActualT, ExpectedT>
+impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher<ActualT>
+    for GeMatcher<ExpectedT>
 {
-    type ActualT = ActualT;
-
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         (*actual >= self.expected).into()
     }

--- a/googletest/src/matchers/is_matcher.rs
+++ b/googletest/src/matchers/is_matcher.rs
@@ -16,34 +16,29 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Matches precisely values matched by `inner`.
 ///
 /// The returned matcher produces a description prefixed by the string
 /// `description`. This is useful in contexts where the test assertion failure
 /// output must include the additional description.
-pub fn is<'a, ActualT: Debug + 'a, InnerMatcherT: Matcher<ActualT = ActualT> + 'a>(
-    description: &'a str,
-    inner: InnerMatcherT,
-) -> impl Matcher<ActualT = ActualT> + 'a {
-    IsMatcher { description, inner, phantom: Default::default() }
+pub fn is<InnerMatcherT>(description: &str, inner: InnerMatcherT) -> IsMatcher<'_, InnerMatcherT> {
+    IsMatcher { description, inner }
 }
 
-struct IsMatcher<'a, ActualT, InnerMatcherT> {
+#[derive(MatcherExt)]
+pub struct IsMatcher<'a, InnerMatcherT> {
     description: &'a str,
     inner: InnerMatcherT,
-    phantom: PhantomData<ActualT>,
 }
 
-impl<'a, ActualT: Debug, InnerMatcherT: Matcher<ActualT = ActualT>> Matcher
-    for IsMatcher<'a, ActualT, InnerMatcherT>
+impl<'a, ActualT: Debug, InnerMatcherT: Matcher<ActualT>> Matcher<ActualT>
+    for IsMatcher<'a, InnerMatcherT>
 {
-    type ActualT = ActualT;
-
-    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
+    fn matches(&self, actual: &ActualT) -> MatcherResult {
         self.inner.matches(actual)
     }
 
@@ -64,7 +59,7 @@ impl<'a, ActualT: Debug, InnerMatcherT: Matcher<ActualT = ActualT>> Matcher
         }
     }
 
-    fn explain_match(&self, actual: &Self::ActualT) -> Description {
+    fn explain_match(&self, actual: &ActualT) -> Description {
         self.inner.explain_match(actual)
     }
 }

--- a/googletest/src/matchers/is_nan_matcher.rs
+++ b/googletest/src/matchers/is_nan_matcher.rs
@@ -14,21 +14,20 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
 use num_traits::float::Float;
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Matches a floating point value which is NaN.
-pub fn is_nan<T: Float + Debug>() -> impl Matcher<ActualT = T> {
-    IsNanMatcher::<T>(Default::default())
+pub fn is_nan() -> IsNanMatcher {
+    IsNanMatcher
 }
 
-struct IsNanMatcher<T>(PhantomData<T>);
+#[derive(MatcherExt)]
+pub struct IsNanMatcher;
 
-impl<T: Float + Debug> Matcher for IsNanMatcher<T> {
-    type ActualT = T;
-
+impl<T: Float + Debug> Matcher<T> for IsNanMatcher {
     fn matches(&self, actual: &T) -> MatcherResult {
         actual.is_nan().into()
     }

--- a/googletest/src/matchers/le_matcher.rs
+++ b/googletest/src/matchers/le_matcher.rs
@@ -14,9 +14,9 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Matches a value less than or equal to (in the sense of `<=`) `expected`.
 ///
@@ -74,22 +74,18 @@ use std::{fmt::Debug, marker::PhantomData};
 ///
 /// You can find the standard library `PartialOrd` implementation in
 /// <https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html#implementors>
-pub fn le<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug>(
-    expected: ExpectedT,
-) -> impl Matcher<ActualT = ActualT> {
-    LeMatcher::<ActualT, _> { expected, phantom: Default::default() }
+pub fn le<ExpectedT>(expected: ExpectedT) -> LeMatcher<ExpectedT> {
+    LeMatcher { expected }
 }
 
-struct LeMatcher<ActualT, ExpectedT> {
+#[derive(MatcherExt)]
+pub struct LeMatcher<ExpectedT> {
     expected: ExpectedT,
-    phantom: PhantomData<ActualT>,
 }
 
-impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
-    for LeMatcher<ActualT, ExpectedT>
+impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher<ActualT>
+    for LeMatcher<ExpectedT>
 {
-    type ActualT = ActualT;
-
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         (*actual <= self.expected).into()
     }

--- a/googletest/src/matchers/lt_matcher.rs
+++ b/googletest/src/matchers/lt_matcher.rs
@@ -14,9 +14,9 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Matches a value less (in the sense of `<`) than `expected`.
 ///
@@ -74,22 +74,18 @@ use std::{fmt::Debug, marker::PhantomData};
 ///
 /// You can find the standard library `PartialOrd` implementation in
 /// <https://doc.rust-lang.org/core/cmp/trait.PartialOrd.html#implementors>
-pub fn lt<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug>(
-    expected: ExpectedT,
-) -> impl Matcher<ActualT = ActualT> {
-    LtMatcher::<ActualT, _> { expected, phantom: Default::default() }
+pub fn lt<ExpectedT>(expected: ExpectedT) -> LtMatcher<ExpectedT> {
+    LtMatcher { expected }
 }
 
-struct LtMatcher<ActualT, ExpectedT> {
+#[derive(MatcherExt)]
+pub struct LtMatcher<ExpectedT> {
     expected: ExpectedT,
-    phantom: PhantomData<ActualT>,
 }
 
-impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher
-    for LtMatcher<ActualT, ExpectedT>
+impl<ActualT: Debug + PartialOrd<ExpectedT>, ExpectedT: Debug> Matcher<ActualT>
+    for LtMatcher<ExpectedT>
 {
-    type ActualT = ActualT;
-
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         (*actual < self.expected).into()
     }

--- a/googletest/src/matchers/matches_regex_matcher.rs
+++ b/googletest/src/matchers/matches_regex_matcher.rs
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 use crate::description::Description;
-use crate::matcher::{Matcher, MatcherResult};
+use crate::matcher::{Matcher, MatcherExt, MatcherResult};
 use regex::Regex;
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::ops::Deref;
 
 /// Matches a string the entirety of which which matches the given regular
@@ -60,38 +59,31 @@ use std::ops::Deref;
 // compiler treats it as a Matcher<str> only and the code
 //   verify_that!("Some value".to_string(), matches_regex(".*value"))?;
 // doesn't compile.
-pub fn matches_regex<ActualT: ?Sized, PatternT: Deref<Target = str>>(
+pub fn matches_regex<PatternT: Deref<Target = str>>(
     pattern: PatternT,
-) -> MatchesRegexMatcher<ActualT, PatternT> {
+) -> MatchesRegexMatcher<PatternT> {
     let adjusted_pattern = format!("^{}$", pattern.deref());
     let regex = Regex::new(adjusted_pattern.as_str()).unwrap();
-    MatchesRegexMatcher {
-        regex,
-        pattern,
-        _adjusted_pattern: adjusted_pattern,
-        phantom: Default::default(),
-    }
+    MatchesRegexMatcher { regex, pattern, _adjusted_pattern: adjusted_pattern }
 }
 
 /// A matcher matching a string-like type matching a given regular expression.
 ///
 /// Intended only to be used from the function [`matches_regex`] only.
 /// Should not be referenced by code outside this library.
-pub struct MatchesRegexMatcher<ActualT: ?Sized, PatternT: Deref<Target = str>> {
+#[derive(MatcherExt)]
+pub struct MatchesRegexMatcher<PatternT: Deref<Target = str>> {
     regex: Regex,
     pattern: PatternT,
     _adjusted_pattern: String,
-    phantom: PhantomData<ActualT>,
 }
 
-impl<PatternT, ActualT> Matcher for MatchesRegexMatcher<ActualT, PatternT>
+impl<PatternT, ActualT> Matcher<ActualT> for MatchesRegexMatcher<PatternT>
 where
     PatternT: Deref<Target = str>,
     ActualT: AsRef<str> + Debug + ?Sized,
 {
-    type ActualT = ActualT;
-
-    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
+    fn matches(&self, actual: &ActualT) -> MatcherResult {
         self.regex.is_match(actual.as_ref()).into()
     }
 
@@ -109,7 +101,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{matches_regex, MatchesRegexMatcher};
+    use super::matches_regex;
     use crate::matcher::{Matcher, MatcherResult};
     use crate::prelude::*;
 
@@ -201,10 +193,10 @@ mod tests {
 
     #[test]
     fn matches_regex_displays_quoted_debug_of_pattern() -> Result<()> {
-        let matcher: MatchesRegexMatcher<&str, _> = matches_regex("\n");
+        let matcher = matches_regex("\n");
 
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("matches the regular expression \"\\n\""))
         )
     }

--- a/googletest/src/matchers/near_matcher.rs
+++ b/googletest/src/matchers/near_matcher.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
 use num_traits::{Float, FloatConst};
 use std::fmt::Debug;
@@ -139,6 +139,7 @@ pub fn approx_eq<T: Debug + Float + FloatConst + Copy>(expected: T) -> NearMatch
 
 /// A matcher which matches floating-point numbers approximately equal to its
 /// expected value.
+#[derive(MatcherExt)]
 pub struct NearMatcher<T: Debug> {
     expected: T,
     max_abs_error: T,
@@ -166,9 +167,7 @@ impl<T: Debug> NearMatcher<T> {
     }
 }
 
-impl<T: Debug + Float> Matcher for NearMatcher<T> {
-    type ActualT = T;
-
+impl<T: Debug + Float> Matcher<T> for NearMatcher<T> {
     fn matches(&self, actual: &T) -> MatcherResult {
         if self.nans_are_equal && self.expected.is_nan() && actual.is_nan() {
             return MatcherResult::Match;

--- a/googletest/src/matchers/none_matcher.rs
+++ b/googletest/src/matchers/none_matcher.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use crate::description::Description;
-use crate::matcher::{Matcher, MatcherResult};
+use crate::matcher::{Matcher, MatcherExt, MatcherResult};
 use std::fmt::Debug;
-use std::marker::PhantomData;
 
 /// Matches an `Option` containing `None`.
 ///
@@ -32,17 +31,14 @@ use std::marker::PhantomData;
 /// # should_pass().unwrap();
 /// # should_fail().unwrap_err();
 /// ```
-pub fn none<T: Debug>() -> impl Matcher<ActualT = Option<T>> {
-    NoneMatcher::<T> { phantom: Default::default() }
+pub fn none() -> NoneMatcher {
+    NoneMatcher
 }
 
-struct NoneMatcher<T> {
-    phantom: PhantomData<T>,
-}
+#[derive(MatcherExt)]
+pub struct NoneMatcher;
 
-impl<T: Debug> Matcher for NoneMatcher<T> {
-    type ActualT = Option<T>;
-
+impl<T: Debug> Matcher<Option<T>> for NoneMatcher {
     fn matches(&self, actual: &Option<T>) -> MatcherResult {
         (actual.is_none()).into()
     }
@@ -63,9 +59,9 @@ mod tests {
 
     #[test]
     fn none_matches_option_with_none() -> Result<()> {
-        let matcher = none::<i32>();
+        let matcher = none();
 
-        let result = matcher.matches(&None);
+        let result = matcher.matches(&None::<i32>);
 
         verify_that!(result, eq(MatcherResult::Match))
     }

--- a/googletest/src/matchers/not_matcher.rs
+++ b/googletest/src/matchers/not_matcher.rs
@@ -14,9 +14,9 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
 };
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 /// Matches the actual value exactly when the inner matcher does _not_ match.
 ///
@@ -33,20 +33,16 @@ use std::{fmt::Debug, marker::PhantomData};
 /// # should_pass().unwrap();
 /// # should_fail().unwrap_err();
 /// ```
-pub fn not<T: Debug, InnerMatcherT: Matcher<ActualT = T>>(
-    inner: InnerMatcherT,
-) -> impl Matcher<ActualT = T> {
-    NotMatcher::<T, _> { inner, phantom: Default::default() }
+pub fn not<InnerMatcherT>(inner: InnerMatcherT) -> NotMatcher<InnerMatcherT> {
+    NotMatcher { inner }
 }
 
-struct NotMatcher<T, InnerMatcherT> {
+#[derive(MatcherExt)]
+pub struct NotMatcher<InnerMatcherT> {
     inner: InnerMatcherT,
-    phantom: PhantomData<T>,
 }
 
-impl<T: Debug, InnerMatcherT: Matcher<ActualT = T>> Matcher for NotMatcher<T, InnerMatcherT> {
-    type ActualT = T;
-
+impl<T: Debug, InnerMatcherT: Matcher<T>> Matcher<T> for NotMatcher<InnerMatcherT> {
     fn matches(&self, actual: &T) -> MatcherResult {
         match self.inner.matches(actual) {
             MatcherResult::Match => MatcherResult::NoMatch,

--- a/googletest/src/matchers/points_to_matcher.rs
+++ b/googletest/src/matchers/points_to_matcher.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use crate::description::Description;
-use crate::matcher::{Matcher, MatcherResult};
+use crate::matcher::{Matcher, MatcherExt, MatcherResult};
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::ops::Deref;
 
 /// Matches a (smart) pointer pointing to a value matched by the [`Matcher`]
@@ -32,30 +31,21 @@ use std::ops::Deref;
 /// # }
 /// # should_pass().unwrap();
 /// ```
-pub fn points_to<ExpectedT, MatcherT, ActualT>(
-    expected: MatcherT,
-) -> impl Matcher<ActualT = ActualT>
-where
-    ExpectedT: Debug,
-    MatcherT: Matcher<ActualT = ExpectedT>,
-    ActualT: Deref<Target = ExpectedT> + Debug + ?Sized,
-{
-    PointsToMatcher { expected, phantom: Default::default() }
+pub fn points_to<MatcherT>(expected: MatcherT) -> PointsToMatcher<MatcherT> {
+    PointsToMatcher { expected }
 }
 
-struct PointsToMatcher<ActualT: ?Sized, MatcherT> {
+#[derive(MatcherExt)]
+pub struct PointsToMatcher<MatcherT> {
     expected: MatcherT,
-    phantom: PhantomData<ActualT>,
 }
 
-impl<ExpectedT, MatcherT, ActualT> Matcher for PointsToMatcher<ActualT, MatcherT>
+impl<ExpectedT, MatcherT, ActualT> Matcher<ActualT> for PointsToMatcher<MatcherT>
 where
     ExpectedT: Debug,
-    MatcherT: Matcher<ActualT = ExpectedT>,
+    MatcherT: Matcher<ExpectedT>,
     ActualT: Deref<Target = ExpectedT> + Debug + ?Sized,
 {
-    type ActualT = ActualT;
-
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         self.expected.matches(actual.deref())
     }

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     description::Description,
-    matcher::{Matcher, MatcherResult},
+    matcher::{Matcher, MatcherExt, MatcherResult},
     matcher_support::{
         edit_distance,
         summarize_diff::{create_diff, create_diff_reversed},
@@ -23,7 +23,6 @@ use crate::{
 };
 use std::borrow::Cow;
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::ops::Deref;
 
 /// Matches a string containing a given substring.
@@ -59,11 +58,10 @@ use std::ops::Deref;
 /// > and expected values when matching strings while
 /// > [`ignoring_ascii_case`][StrMatcherConfigurator::ignoring_ascii_case] is
 /// > set.
-pub fn contains_substring<A: ?Sized, T>(expected: T) -> StrMatcher<A, T> {
+pub fn contains_substring<T>(expected: T) -> StrMatcher<T> {
     StrMatcher {
         configuration: Configuration { mode: MatchMode::Contains, ..Default::default() },
         expected,
-        phantom: Default::default(),
     }
 }
 
@@ -99,11 +97,10 @@ pub fn contains_substring<A: ?Sized, T>(expected: T) -> StrMatcher<A, T> {
 ///
 /// See the [`StrMatcherConfigurator`] extension trait for more options on how
 /// the string is matched.
-pub fn starts_with<A: ?Sized, T>(expected: T) -> StrMatcher<A, T> {
+pub fn starts_with<T>(expected: T) -> StrMatcher<T> {
     StrMatcher {
         configuration: Configuration { mode: MatchMode::StartsWith, ..Default::default() },
         expected,
-        phantom: Default::default(),
     }
 }
 
@@ -139,11 +136,10 @@ pub fn starts_with<A: ?Sized, T>(expected: T) -> StrMatcher<A, T> {
 ///
 /// See the [`StrMatcherConfigurator`] extension trait for more options on how
 /// the string is matched.
-pub fn ends_with<A: ?Sized, T>(expected: T) -> StrMatcher<A, T> {
+pub fn ends_with<T>(expected: T) -> StrMatcher<T> {
     StrMatcher {
         configuration: Configuration { mode: MatchMode::EndsWith, ..Default::default() },
         expected,
-        phantom: Default::default(),
     }
 }
 
@@ -152,7 +148,7 @@ pub fn ends_with<A: ?Sized, T>(expected: T) -> StrMatcher<A, T> {
 /// Matchers which match against string values and, through configuration,
 /// specialise to [`StrMatcher`] implement this trait. That includes
 /// [`EqMatcher`] and [`StrMatcher`].
-pub trait StrMatcherConfigurator<ActualT: ?Sized, ExpectedT> {
+pub trait StrMatcherConfigurator<ExpectedT> {
     /// Configures the matcher to ignore any leading whitespace in either the
     /// actual or the expected value.
     ///
@@ -171,7 +167,7 @@ pub trait StrMatcherConfigurator<ActualT: ?Sized, ExpectedT> {
     /// When all other configuration options are left as the defaults, this is
     /// equivalent to invoking [`str::trim_start`] on both the expected and
     /// actual value.
-    fn ignoring_leading_whitespace(self) -> StrMatcher<ActualT, ExpectedT>;
+    fn ignoring_leading_whitespace(self) -> StrMatcher<ExpectedT>;
 
     /// Configures the matcher to ignore any trailing whitespace in either the
     /// actual or the expected value.
@@ -191,7 +187,7 @@ pub trait StrMatcherConfigurator<ActualT: ?Sized, ExpectedT> {
     /// When all other configuration options are left as the defaults, this is
     /// equivalent to invoking [`str::trim_end`] on both the expected and
     /// actual value.
-    fn ignoring_trailing_whitespace(self) -> StrMatcher<ActualT, ExpectedT>;
+    fn ignoring_trailing_whitespace(self) -> StrMatcher<ExpectedT>;
 
     /// Configures the matcher to ignore both leading and trailing whitespace in
     /// either the actual or the expected value.
@@ -215,7 +211,7 @@ pub trait StrMatcherConfigurator<ActualT: ?Sized, ExpectedT> {
     /// When all other configuration options are left as the defaults, this is
     /// equivalent to invoking [`str::trim`] on both the expected and actual
     /// value.
-    fn ignoring_outer_whitespace(self) -> StrMatcher<ActualT, ExpectedT>;
+    fn ignoring_outer_whitespace(self) -> StrMatcher<ExpectedT>;
 
     /// Configures the matcher to ignore ASCII case when comparing values.
     ///
@@ -237,7 +233,7 @@ pub trait StrMatcherConfigurator<ActualT: ?Sized, ExpectedT> {
     ///
     /// This is **not guaranteed** to match strings with differing upper/lower
     /// case characters outside of the codepoints 0-127 covered by ASCII.
-    fn ignoring_ascii_case(self) -> StrMatcher<ActualT, ExpectedT>;
+    fn ignoring_ascii_case(self) -> StrMatcher<ExpectedT>;
 
     /// Configures the matcher to match only strings which otherwise satisfy the
     /// conditions a number times matched by the matcher `times`.
@@ -272,10 +268,7 @@ pub trait StrMatcherConfigurator<ActualT: ?Sized, ExpectedT> {
     /// This is only meaningful when the matcher was constructed with
     /// [`contains_substring`]. This method will panic when it is used with any
     /// other matcher construction.
-    fn times(
-        self,
-        times: impl Matcher<ActualT = usize> + 'static,
-    ) -> StrMatcher<ActualT, ExpectedT>;
+    fn times(self, times: impl Matcher<usize> + 'static) -> StrMatcher<ExpectedT>;
 }
 
 /// A matcher which matches equality or containment of a string-like value in a
@@ -287,19 +280,17 @@ pub trait StrMatcherConfigurator<ActualT: ?Sized, ExpectedT> {
 ///  * [`contains_substring`],
 ///  * [`starts_with`],
 ///  * [`ends_with`].
-pub struct StrMatcher<ActualT: ?Sized, ExpectedT> {
+#[derive(MatcherExt)]
+pub struct StrMatcher<ExpectedT> {
     expected: ExpectedT,
     configuration: Configuration,
-    phantom: PhantomData<ActualT>,
 }
 
-impl<ExpectedT, ActualT> Matcher for StrMatcher<ActualT, ExpectedT>
+impl<ExpectedT, ActualT> Matcher<ActualT> for StrMatcher<ExpectedT>
 where
     ExpectedT: Deref<Target = str> + Debug,
     ActualT: AsRef<str> + Debug + ?Sized,
 {
-    type ActualT = ActualT;
-
     fn matches(&self, actual: &ActualT) -> MatcherResult {
         self.configuration.do_strings_match(self.expected.deref(), actual.as_ref()).into()
     }
@@ -313,10 +304,10 @@ where
     }
 }
 
-impl<ActualT: ?Sized, ExpectedT, MatcherT: Into<StrMatcher<ActualT, ExpectedT>>>
-    StrMatcherConfigurator<ActualT, ExpectedT> for MatcherT
+impl<ExpectedT, MatcherT: Into<StrMatcher<ExpectedT>>> StrMatcherConfigurator<ExpectedT>
+    for MatcherT
 {
-    fn ignoring_leading_whitespace(self) -> StrMatcher<ActualT, ExpectedT> {
+    fn ignoring_leading_whitespace(self) -> StrMatcher<ExpectedT> {
         let existing = self.into();
         StrMatcher {
             configuration: existing.configuration.ignoring_leading_whitespace(),
@@ -324,7 +315,7 @@ impl<ActualT: ?Sized, ExpectedT, MatcherT: Into<StrMatcher<ActualT, ExpectedT>>>
         }
     }
 
-    fn ignoring_trailing_whitespace(self) -> StrMatcher<ActualT, ExpectedT> {
+    fn ignoring_trailing_whitespace(self) -> StrMatcher<ExpectedT> {
         let existing = self.into();
         StrMatcher {
             configuration: existing.configuration.ignoring_trailing_whitespace(),
@@ -332,20 +323,17 @@ impl<ActualT: ?Sized, ExpectedT, MatcherT: Into<StrMatcher<ActualT, ExpectedT>>>
         }
     }
 
-    fn ignoring_outer_whitespace(self) -> StrMatcher<ActualT, ExpectedT> {
+    fn ignoring_outer_whitespace(self) -> StrMatcher<ExpectedT> {
         let existing = self.into();
         StrMatcher { configuration: existing.configuration.ignoring_outer_whitespace(), ..existing }
     }
 
-    fn ignoring_ascii_case(self) -> StrMatcher<ActualT, ExpectedT> {
+    fn ignoring_ascii_case(self) -> StrMatcher<ExpectedT> {
         let existing = self.into();
         StrMatcher { configuration: existing.configuration.ignoring_ascii_case(), ..existing }
     }
 
-    fn times(
-        self,
-        times: impl Matcher<ActualT = usize> + 'static,
-    ) -> StrMatcher<ActualT, ExpectedT> {
+    fn times(self, times: impl Matcher<usize> + 'static) -> StrMatcher<ExpectedT> {
         let existing = self.into();
         if !matches!(existing.configuration.mode, MatchMode::Contains) {
             panic!("The times() configurator is only meaningful with contains_substring().");
@@ -354,25 +342,25 @@ impl<ActualT: ?Sized, ExpectedT, MatcherT: Into<StrMatcher<ActualT, ExpectedT>>>
     }
 }
 
-impl<A: ?Sized, T: Deref<Target = str>> From<EqMatcher<A, T>> for StrMatcher<A, T> {
-    fn from(value: EqMatcher<A, T>) -> Self {
+impl<T: Deref<Target = str>> From<EqMatcher<T>> for StrMatcher<T> {
+    fn from(value: EqMatcher<T>) -> Self {
         Self::with_default_config(value.expected)
     }
 }
 
-impl<A: ?Sized, T: Deref<Target = str>> From<EqDerefOfMatcher<A, T>> for StrMatcher<A, T> {
-    fn from(value: EqDerefOfMatcher<A, T>) -> Self {
+impl<T: Deref<Target = str>> From<EqDerefOfMatcher<T>> for StrMatcher<T> {
+    fn from(value: EqDerefOfMatcher<T>) -> Self {
         Self::with_default_config(value.expected)
     }
 }
 
-impl<A: ?Sized, T> StrMatcher<A, T> {
+impl<T> StrMatcher<T> {
     /// Returns a [`StrMatcher`] with a default configuration to match against
     /// the given expected value.
     ///
     /// This default configuration is sensitive to whitespace and case.
     fn with_default_config(expected: T) -> Self {
-        Self { expected, configuration: Default::default(), phantom: Default::default() }
+        Self { expected, configuration: Default::default() }
     }
 }
 
@@ -387,7 +375,7 @@ struct Configuration {
     ignore_leading_whitespace: bool,
     ignore_trailing_whitespace: bool,
     case_policy: CasePolicy,
-    times: Option<Box<dyn Matcher<ActualT = usize>>>,
+    times: Option<Box<dyn Matcher<usize>>>,
 }
 
 #[derive(Clone)]
@@ -467,7 +455,7 @@ impl Configuration {
         }
     }
 
-    // StrMatcher::describe redirects immediately to this function.
+    // StrMatcher::<str>::describe redirects immediately to this function.
     fn describe(&self, matcher_result: MatcherResult, expected: &str) -> Description {
         let mut addenda: Vec<Cow<'static, str>> = Vec::with_capacity(3);
         match (self.ignore_leading_whitespace, self.ignore_trailing_whitespace) {
@@ -570,7 +558,7 @@ impl Configuration {
         Self { case_policy: CasePolicy::IgnoreAscii, ..self }
     }
 
-    fn times(self, times: impl Matcher<ActualT = usize> + 'static) -> Self {
+    fn times(self, times: impl Matcher<usize> + 'static) -> Self {
         Self { times: Some(Box::new(times)), ..self }
     }
 }
@@ -811,48 +799,45 @@ mod tests {
 
     #[test]
     fn describes_itself_for_matching_result() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string");
+        let matcher = StrMatcher::with_default_config("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("is equal to \"A string\""))
         )
     }
 
     #[test]
     fn describes_itself_for_non_matching_result() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string");
+        let matcher = StrMatcher::with_default_config("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::NoMatch),
+            Matcher::<str>::describe(&matcher, MatcherResult::NoMatch),
             displays_as(eq("isn't equal to \"A string\""))
         )
     }
 
     #[test]
     fn describes_itself_for_matching_result_ignoring_leading_whitespace() -> Result<()> {
-        let matcher: StrMatcher<&str, _> =
-            StrMatcher::with_default_config("A string").ignoring_leading_whitespace();
+        let matcher = StrMatcher::with_default_config("A string").ignoring_leading_whitespace();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("is equal to \"A string\" (ignoring leading whitespace)"))
         )
     }
 
     #[test]
     fn describes_itself_for_non_matching_result_ignoring_leading_whitespace() -> Result<()> {
-        let matcher: StrMatcher<&str, _> =
-            StrMatcher::with_default_config("A string").ignoring_leading_whitespace();
+        let matcher = StrMatcher::with_default_config("A string").ignoring_leading_whitespace();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::NoMatch),
+            Matcher::<str>::describe(&matcher, MatcherResult::NoMatch),
             displays_as(eq("isn't equal to \"A string\" (ignoring leading whitespace)"))
         )
     }
 
     #[test]
     fn describes_itself_for_matching_result_ignoring_trailing_whitespace() -> Result<()> {
-        let matcher: StrMatcher<&str, _> =
-            StrMatcher::with_default_config("A string").ignoring_trailing_whitespace();
+        let matcher = StrMatcher::with_default_config("A string").ignoring_trailing_whitespace();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("is equal to \"A string\" (ignoring trailing whitespace)"))
         )
     }
@@ -860,20 +845,18 @@ mod tests {
     #[test]
     fn describes_itself_for_matching_result_ignoring_leading_and_trailing_whitespace() -> Result<()>
     {
-        let matcher: StrMatcher<&str, _> =
-            StrMatcher::with_default_config("A string").ignoring_outer_whitespace();
+        let matcher = StrMatcher::with_default_config("A string").ignoring_outer_whitespace();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("is equal to \"A string\" (ignoring leading and trailing whitespace)"))
         )
     }
 
     #[test]
     fn describes_itself_for_matching_result_ignoring_ascii_case() -> Result<()> {
-        let matcher: StrMatcher<&str, _> =
-            StrMatcher::with_default_config("A string").ignoring_ascii_case();
+        let matcher = StrMatcher::with_default_config("A string").ignoring_ascii_case();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("is equal to \"A string\" (ignoring ASCII case)"))
         )
     }
@@ -881,11 +864,11 @@ mod tests {
     #[test]
     fn describes_itself_for_matching_result_ignoring_ascii_case_and_leading_whitespace()
     -> Result<()> {
-        let matcher: StrMatcher<&str, _> = StrMatcher::with_default_config("A string")
+        let matcher = StrMatcher::with_default_config("A string")
             .ignoring_leading_whitespace()
             .ignoring_ascii_case();
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq(
                 "is equal to \"A string\" (ignoring leading whitespace, ignoring ASCII case)"
             ))
@@ -894,63 +877,63 @@ mod tests {
 
     #[test]
     fn describes_itself_for_matching_result_in_contains_mode() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = contains_substring("A string");
+        let matcher = contains_substring("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("contains a substring \"A string\""))
         )
     }
 
     #[test]
     fn describes_itself_for_non_matching_result_in_contains_mode() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = contains_substring("A string");
+        let matcher = contains_substring("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::NoMatch),
+            Matcher::<str>::describe(&matcher, MatcherResult::NoMatch),
             displays_as(eq("does not contain a substring \"A string\""))
         )
     }
 
     #[test]
     fn describes_itself_with_count_number() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = contains_substring("A string").times(gt(2));
+        let matcher = contains_substring("A string").times(gt(2));
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("contains a substring \"A string\" (count is greater than 2)"))
         )
     }
 
     #[test]
     fn describes_itself_for_matching_result_in_starts_with_mode() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = starts_with("A string");
+        let matcher = starts_with("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("starts with prefix \"A string\""))
         )
     }
 
     #[test]
     fn describes_itself_for_non_matching_result_in_starts_with_mode() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = starts_with("A string");
+        let matcher = starts_with("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::NoMatch),
+            Matcher::<str>::describe(&matcher, MatcherResult::NoMatch),
             displays_as(eq("does not start with \"A string\""))
         )
     }
 
     #[test]
     fn describes_itself_for_matching_result_in_ends_with_mode() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = ends_with("A string");
+        let matcher = ends_with("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::Match),
+            Matcher::<str>::describe(&matcher, MatcherResult::Match),
             displays_as(eq("ends with suffix \"A string\""))
         )
     }
 
     #[test]
     fn describes_itself_for_non_matching_result_in_ends_with_mode() -> Result<()> {
-        let matcher: StrMatcher<&str, _> = ends_with("A string");
+        let matcher = ends_with("A string");
         verify_that!(
-            Matcher::describe(&matcher, MatcherResult::NoMatch),
+            Matcher::<str>::describe(&matcher, MatcherResult::NoMatch),
             displays_as(eq("does not end with \"A string\""))
         )
     }

--- a/googletest/tests/elements_are_matcher_test.rs
+++ b/googletest/tests/elements_are_matcher_test.rs
@@ -109,7 +109,7 @@ fn elements_are_explain_match_wrong_size() -> Result<()> {
     )
 }
 
-fn create_matcher() -> impl Matcher<ActualT = Vec<i32>> {
+fn create_matcher() -> impl Matcher<Vec<i32>> {
     elements_are![eq(1)]
 }
 

--- a/googletest/tests/tuple_matcher_test.rs
+++ b/googletest/tests/tuple_matcher_test.rs
@@ -176,7 +176,7 @@ fn tuple_matcher_with_trailing_comma_matches_matching_12_tuple() -> Result<()> {
 #[test]
 fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
     verify_that!(
-        (eq::<i32, _>(1),).describe(MatcherResult::Match),
+        Matcher::<(i32,)>::describe(&(eq(1),), MatcherResult::Match),
         displays_as(eq(indoc!(
             "
             is a tuple whose values respectively match:
@@ -188,7 +188,7 @@ fn tuple_matcher_1_has_correct_description_for_match() -> Result<()> {
 #[test]
 fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
-        (eq::<i32, _>(1),).describe(MatcherResult::NoMatch),
+        Matcher::<(i32,)>::describe(&(eq(1),), MatcherResult::NoMatch),
         displays_as(eq(indoc!(
             "
             is a tuple whose values do not respectively match:
@@ -200,7 +200,7 @@ fn tuple_matcher_1_has_correct_description_for_mismatch() -> Result<()> {
 #[test]
 fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
     verify_that!(
-        (eq::<i32, _>(1), eq::<i32, _>(2)).describe(MatcherResult::Match),
+        Matcher::<(i32, i32)>::describe(&(eq(1), eq(2)), MatcherResult::Match),
         displays_as(eq(indoc!(
             "
             is a tuple whose values respectively match:
@@ -213,7 +213,7 @@ fn tuple_matcher_2_has_correct_description_for_match() -> Result<()> {
 #[test]
 fn tuple_matcher_2_has_correct_description_for_mismatch() -> Result<()> {
     verify_that!(
-        (eq::<i32, _>(1), eq::<i32, _>(2)).describe(MatcherResult::NoMatch),
+        Matcher::<(i32, i32)>::describe(&(eq(1), eq(2)), MatcherResult::NoMatch),
         displays_as(eq(indoc!(
             "
             is a tuple whose values do not respectively match:

--- a/googletest/tests/unordered_elements_are_matcher_test.rs
+++ b/googletest/tests/unordered_elements_are_matcher_test.rs
@@ -208,7 +208,7 @@ fn unordered_elements_are_unmatchable_actual_description_mismatch() -> Result<()
     )
 }
 
-fn create_matcher() -> impl Matcher<ActualT = Vec<i32>> {
+fn create_matcher() -> impl Matcher<Vec<i32>> {
     unordered_elements_are![eq(1)]
 }
 
@@ -217,7 +217,7 @@ fn unordered_elements_are_works_when_matcher_is_created_in_subroutine() -> Resul
     verify_that!(vec![1], create_matcher())
 }
 
-fn create_matcher_for_map() -> impl Matcher<ActualT = HashMap<i32, i32>> {
+fn create_matcher_for_map() -> impl Matcher<HashMap<i32, i32>> {
     unordered_elements_are![(eq(1), eq(1))]
 }
 
@@ -352,7 +352,7 @@ fn is_contained_in_matches_hash_map_with_trailing_comma() -> Result<()> {
 
 #[test]
 fn is_contained_in_matches_when_container_is_empty() -> Result<()> {
-    verify_that!(vec![], is_contained_in!(eq::<i32, _>(2), eq(3), eq(4)))
+    verify_that!(vec![1; 0], is_contained_in!(eq(2), eq(3), eq(4)))
 }
 
 #[test]

--- a/googletest_macro/src/lib.rs
+++ b/googletest_macro/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use quote::quote;
-use syn::{parse_macro_input, Attribute, ItemFn, ReturnType};
+use syn::{parse_macro_input, Attribute, DeriveInput, ItemFn, ReturnType};
 
 /// Marks a test to be run by the Google Rust test runner.
 ///
@@ -162,4 +162,16 @@ fn is_test_attribute(attr: &Attribute) -> bool {
         || (first_segment.ident == "rstest"
             && last_segment.ident == "rstest"
             && attr.path().segments.len() <= 2)
+}
+
+#[proc_macro_derive(MatcherExt)]
+pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    // eprintln!("{ast:#?}");
+    let DeriveInput { ident, generics, .. } = ast;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    quote! {
+        impl #impl_generics MatcherExt for #ident #ty_generics #where_clause {}
+    }
+    .into()
 }


### PR DESCRIPTION
This change will fix #323.

Matchers will be more generic so they will be able to handle different `ActualT` types, which is most necessary for types with parametric lifetime. However, this will bring back the issues with `Matcher::and` and `Matcher::or` being non-deterministic. This is solved by moving these functions to a non-generic extension trait.