### PR TITLE
Use DisjunctionMatcher for any![] macro.

### DIFF
--- a/googletest/src/description.rs
+++ b/googletest/src/description.rs
@@ -90,6 +90,7 @@ pub struct Description {
     elements: List,
     initial_indentation: usize,
     is_conjunction: bool,
+    is_disjunction: bool,
 }
 
 impl Description {
@@ -201,6 +202,11 @@ impl Description {
         self.elements.is_empty()
     }
 
+    pub(crate) fn push_in_last_nested(mut self, inner: Description) -> Self {
+        self.elements.push_at_end(inner.elements);
+        self
+    }
+
     pub(crate) fn conjunction_description(self) -> Self {
         Self { is_conjunction: true, ..self }
     }
@@ -209,9 +215,12 @@ impl Description {
         self.is_conjunction
     }
 
-    pub(crate) fn push_in_last_nested(mut self, inner: Description) -> Self {
-        self.elements.push_at_end(inner.elements);
-        self
+    pub(crate) fn disjunction_description(self) -> Self {
+        Self { is_disjunction: true, ..self }
+    }
+
+    pub(crate) fn is_disjunction_description(&self) -> bool {
+        self.is_disjunction
     }
 }
 

--- a/googletest/src/matchers/conjunction_matcher.rs
+++ b/googletest/src/matchers/conjunction_matcher.rs
@@ -76,7 +76,7 @@ where
                 } else {
                     Description::new()
                         .bullet_list()
-                        .collect([self.m1.explain_match(actual), self.m2.explain_match(actual)])
+                        .collect([m1_description, self.m2.explain_match(actual)])
                         .conjunction_description()
                 }
             }
@@ -96,10 +96,9 @@ where
             Description::new()
                 .text(header)
                 .nested(
-                    Description::new().bullet_list().collect([
-                        self.m1.describe(matcher_result),
-                        self.m2.describe(matcher_result),
-                    ]),
+                    Description::new()
+                        .bullet_list()
+                        .collect([m1_description, self.m2.describe(matcher_result)]),
                 )
                 .conjunction_description()
         }

--- a/googletest/src/matchers/disjunction_matcher.rs
+++ b/googletest/src/matchers/disjunction_matcher.rs
@@ -21,8 +21,18 @@ use crate::{
 };
 use std::fmt::Debug;
 
-/// Matcher created by [`Matcher::or`].
+/// Matcher created by [`Matcher::or`] and [`any!`].
 ///
+/// Both [`Matcher::or`] and [`any!`] nest on m1. In other words,
+/// both `x.or(y).or(z)` and `any![x, y, z]` produce:
+/// ```ignore
+/// DisjunctionMatcher {
+///     m1: DisjunctionMatcher {
+///         m1: x, m2: y
+///     },
+///     m2: z
+/// }
+/// ```
 /// **For internal use only. API stablility is not guaranteed!**
 #[doc(hidden)]
 pub struct DisjunctionMatcher<M1, M2> {
@@ -31,7 +41,7 @@ pub struct DisjunctionMatcher<M1, M2> {
 }
 
 impl<M1, M2> DisjunctionMatcher<M1, M2> {
-    pub(crate) fn new(m1: M1, m2: M2) -> Self {
+    pub fn new(m1: M1, m2: M2) -> Self {
         Self { m1, m2 }
     }
 }
@@ -50,15 +60,42 @@ where
     }
 
     fn explain_match(&self, actual: &M1::ActualT) -> Description {
-        Description::new()
-            .nested(self.m1.explain_match(actual))
-            .text("and")
-            .nested(self.m2.explain_match(actual))
+        match (self.m1.matches(actual), self.m2.matches(actual)) {
+            (MatcherResult::NoMatch, MatcherResult::Match) => self.m1.explain_match(actual),
+            (MatcherResult::Match, MatcherResult::NoMatch) => self.m2.explain_match(actual),
+            (_, _) => {
+                let m1_description = self.m1.explain_match(actual);
+                if m1_description.is_disjunction_description() {
+                    m1_description.nested(self.m2.explain_match(actual))
+                } else {
+                    Description::new()
+                        .bullet_list()
+                        .collect([m1_description, self.m2.explain_match(actual)])
+                        .disjunction_description()
+                }
+            }
+        }
     }
 
     fn describe(&self, matcher_result: MatcherResult) -> Description {
-        format!("{}, or {}", self.m1.describe(matcher_result), self.m2.describe(matcher_result))
-            .into()
+        let m1_description = self.m1.describe(matcher_result);
+        if m1_description.is_disjunction_description() {
+            m1_description.push_in_last_nested(self.m2.describe(matcher_result))
+        } else {
+            let header = if matcher_result.into() {
+                "has at least one of the following properties:"
+            } else {
+                "has all of the following properties:"
+            };
+            Description::new()
+                .text(header)
+                .nested(
+                    Description::new()
+                        .bullet_list()
+                        .collect([m1_description, self.m2.describe(matcher_result)]),
+                )
+                .disjunction_description()
+        }
     }
 }
 
@@ -90,11 +127,12 @@ mod tests {
             err(displays_as(contains_substring(indoc!(
                 "
                 Value of: 1
-                Expected: never matches, or never matches
+                Expected: has at least one of the following properties:
+                  * never matches
+                  * never matches
                 Actual: 1,
-                    which is anything
-                  and
-                    which is anything
+                  * which is anything
+                  * which is anything
                 "
             ))))
         )

--- a/googletest/src/matchers/mod.rs
+++ b/googletest/src/matchers/mod.rs
@@ -105,7 +105,6 @@ pub use crate::{
 // should only be used through their respective macros.
 #[doc(hidden)]
 pub mod __internal_unstable_do_not_depend_on_these {
-    pub use super::any_matcher::internal::AnyMatcher;
     pub use super::conjunction_matcher::ConjunctionMatcher;
     pub use super::disjunction_matcher::DisjunctionMatcher;
     pub use super::elements_are_matcher::internal::ElementsAre;

--- a/googletest/tests/any_matcher_test.rs
+++ b/googletest/tests/any_matcher_test.rs
@@ -17,11 +17,6 @@ use googletest::prelude::*;
 use indoc::indoc;
 
 #[test]
-fn does_not_match_value_when_list_is_empty() -> Result<()> {
-    verify_that!((), not(any!()))
-}
-
-#[test]
 fn matches_value_with_single_matching_component() -> Result<()> {
     verify_that!(123, any!(eq(123)))
 }
@@ -63,11 +58,6 @@ fn mismatch_description_two_failed_matchers() -> Result<()> {
         any!(starts_with("One"), starts_with("Two")).explain_match("Three"),
         displays_as(eq("* which does not start with \"One\"\n* which does not start with \"Two\""))
     )
-}
-
-#[test]
-fn mismatch_description_empty_matcher() -> Result<()> {
-    verify_that!(any!().explain_match("Three"), displays_as(eq("which never matches")))
 }
 
 #[test]


### PR DESCRIPTION
This PR update:
* the matcher used in `any!` to rely on `DisjunctionMatcher` and not on `AnyMatcher` (which is removed).
*   `DisjunctionMatcher` to generate `Description` more similar to `AnyMatcher`.
* Remove the support of `any![]` (with empty matcher list). This should be implemented as `not(anything())` which is a surprising behavior.
* * This could not be done for `all!` since it is used in the `matches_pattern!` often with empty matcher list.

This PR will allow the usage of `any!` where a matcher is constrain with HRTB is expected. See https://github.com/google/googletest-rust/issues/323 for more details.