### PR TITLE
Add support for TEST(...) and TEST_F(...) macro to mimic the style of the C++ library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,39 @@ fn failing_fatal_assertion_after_non_fatal_assertion() -> Result<()> {
 }
 ```
 
+### GoogleTest style `TEST(...)` and `TEST_F(...)`
+
+GoogleTest supports both the common Rust test declaration, i.e.
+
+```
+#[test]
+fn my_test() -> Result<()> { ... }
+```
+
+as well as the style provided by the [original GoogleTest](https://github.com/google/googletest), i.e.
+
+```
+TEST(MyTestSuite, TestCase, {...});
+```
+
+The original GoogleTest style also supports `TEST_F` with a [`googletest::TestFixture`] object for common setup:
+
+```
+struct TestWithFakeDatabase { ... }
+
+impl googletest::TestFixture ofr TestWithFakeDatabase {
+  fn create() -> Self { ... }
+  fn set_up(&mut self) {
+    // Set up database
+    ...
+  }
+}
+
+TEST_F(TestWithFakeDatabase, NotFound, { ... });
+
+TEST_F(TestWithFakeDatabase, Found, { ... });
+```
+
 ### Interoperability
 
 You can use the `#[googletest::test]` macro together with many other libraries

--- a/googletest/src/fixtures.rs
+++ b/googletest/src/fixtures.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod all_matcher_test;
-mod any_matcher_test;
-mod colorized_diff_test;
-mod composition_test;
-mod elements_are_matcher_test;
-mod field_matcher_test;
-mod fixtures_test;
-mod matches_pattern_test;
-mod pointwise_matcher_test;
-mod property_matcher_test;
-#[cfg(feature = "proptest")]
-mod proptest_integration_test;
-mod tuple_matcher_test;
-mod unordered_elements_are_matcher_test;
+/// An interface for setting up and tearing down data used in multiple tests.
+///
+/// The test fixture passed to [`TEST_F`](googletest_macro::TEST_F) must
+/// implement this interface.
+pub trait TestFixture {
+    /// Create the the test fixture
+    fn create() -> Self;
+
+    /// Set up the data in the test fixture
+    fn set_up(&mut self) {}
+
+    /// Tear down the data in the test fixture. Can fail the test by returning
+    /// an error.
+    fn tear_down(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+}

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -22,6 +22,7 @@ extern crate quickcheck;
 #[macro_use]
 pub mod assertions;
 pub mod description;
+pub mod fixtures;
 pub mod internal;
 pub mod matcher;
 pub mod matcher_support;
@@ -42,6 +43,7 @@ pub mod matchers;
 /// }
 /// ```
 pub mod prelude {
+    pub use super::fixtures::TestFixture;
     pub use super::matcher::Matcher;
     pub use super::matchers::*;
     pub use super::verify_current_test_outcome;
@@ -50,6 +52,8 @@ pub mod prelude {
     pub use super::Result;
     // Assert macros
     pub use super::{assert_that, expect_pred, expect_that, fail, verify_pred, verify_that};
+    // Fixture macros
+    pub use super::googletest_macro::{TEST, TEST_F};
 }
 
 pub use googletest_macro::test;

--- a/googletest/tests/fixtures_test.rs
+++ b/googletest/tests/fixtures_test.rs
@@ -1,0 +1,79 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use googletest::prelude::*;
+
+TEST!(MyTestSuite, MyTest, { verify_that!(1, eq(1)) });
+
+struct MyFixture;
+
+impl TestFixture for MyFixture {
+    fn create() -> Self {
+        MyFixture
+    }
+}
+
+TEST_F!(MyFixture, FixturedTest, { verify_that!(1, eq(1)) });
+
+struct MyOtherFixture;
+
+impl TestFixture for MyOtherFixture {
+    fn create() -> Self {
+        Self
+    }
+}
+
+TEST_F!(MyOtherFixture, FixturedTest, { verify_that!(1, eq(1)) });
+
+struct ParamFixture<T>(std::marker::PhantomData<T>);
+
+impl<T> TestFixture for ParamFixture<T> {
+    fn create() -> Self {
+        Self(Default::default())
+    }
+}
+TEST_F!(ParamFixture<i32>, FixturedTest, { verify_that!(1, eq(1)) });
+TEST_F!(ParamFixture<(i32, i32)>, FixturedTest, { verify_that!(1, eq(1)) });
+
+struct ConstParamFixture<const N: i32>;
+impl<const N: i32> TestFixture for ConstParamFixture<N> {
+    fn create() -> Self {
+        Self
+    }
+}
+TEST_F!(ConstParamFixture<123>, FixturedTest, { verify_that!(1, eq(1)) });
+
+struct FakeFixture {
+    set_up_has_run: bool,
+    test_case_has_run: bool,
+}
+
+impl TestFixture for FakeFixture {
+    fn create() -> Self {
+        Self { set_up_has_run: false, test_case_has_run: false }
+    }
+    fn set_up(&mut self) {
+        self.set_up_has_run = true;
+    }
+
+    fn tear_down(&mut self) -> googletest::Result<()> {
+        verify_that!(self.test_case_has_run, eq(true))
+    }
+}
+
+TEST_F!(FakeFixture, BeforeAndAfterAreCalled, {
+    verify_that!(self.set_up_has_run, eq(true))?;
+    self.test_case_has_run = true;
+    Ok(())
+});

--- a/googletest_macro/Cargo.toml
+++ b/googletest_macro/Cargo.toml
@@ -26,6 +26,7 @@ authors = [
 ]
 
 [dependencies]
+proc-macro2 = "1.0.78"
 quote = "1.0.33"
 syn = {version = "2.0.39", features = ["full"]}
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -159,3 +159,8 @@ test = false
 name = "verify_predicate_with_failure_as_method_in_submodule"
 path = "src/verify_predicate_with_failure_as_method_in_submodule.rs"
 test = false
+
+[[bin]]
+name = "failure_in_fixtures_tear_down"
+path = "src/failure_in_fixtures_tear_down.rs"
+test = false

--- a/integration_tests/src/failure_in_fixtures_tear_down.rs
+++ b/integration_tests/src/failure_in_fixtures_tear_down.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod all_matcher_test;
-mod any_matcher_test;
-mod colorized_diff_test;
-mod composition_test;
-mod elements_are_matcher_test;
-mod field_matcher_test;
-mod fixtures_test;
-mod matches_pattern_test;
-mod pointwise_matcher_test;
-mod property_matcher_test;
-#[cfg(feature = "proptest")]
-mod proptest_integration_test;
-mod tuple_matcher_test;
-mod unordered_elements_are_matcher_test;
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use googletest::prelude::*;
+    struct FailingTearDown;
+
+    impl TestFixture for FailingTearDown {
+        fn create() -> Self {
+            Self
+        }
+        fn tear_down(&mut self) -> googletest::Result<()> {
+            fail!()
+        }
+    }
+
+    TEST_F!(FailingTearDown, TearDownFails, { Ok(()) });
+}

--- a/integration_tests/src/integration_tests.rs
+++ b/integration_tests/src/integration_tests.rs
@@ -751,4 +751,11 @@ mod tests {
         );
         Command::new(command_path)
     }
+
+    #[test]
+    fn fail_in_fixtures_after() -> Result<()> {
+        let output = run_external_process_in_tests_directory("failure_in_fixtures_tear_down")?;
+
+        verify_that!(output, contains_substring("Test failed"))
+    }
 }

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -35,6 +35,7 @@ INTEGRATION_TEST_BINARIES=(
   "failure_due_to_fail_macro_with_empty_message"
   "failure_due_to_fail_macro_with_format_arguments"
   "failure_due_to_returned_error"
+  "failure_in_fixtures_tear_down"
   "fatal_and_non_fatal_failure"
   "first_failure_aborts"
   "google_test_with_rstest"


### PR DESCRIPTION
This PR adds a new style to declare test, diverging from the Rust style but closer to the [original GoogleTest style](http://google.github.io/googletest/primer.html#same-data-multiple-tests).

`TEST(...)` does not provide new features , but is only a new way to declare tests.

`TEST_F(...)` allows to pass a `TestFixture`, which can allow multiple tests to share set up and tear down logic.