### PR TITLE
Fix Clippy warning

### DIFF
--- a/googletest/src/matcher_support/summarize_diff.rs
+++ b/googletest/src/matcher_support/summarize_diff.rs
@@ -105,11 +105,11 @@ struct BufferedSummary<'a> {
 impl<'a> BufferedSummary<'a> {
     // Appends a new line which is common to both actual and expected.
     fn feed_common_lines(&mut self, common_line: &'a str) {
-        if let Buffer::CommonLineBuffer(ref mut common_lines) = self.buffer {
+        if let Buffer::CommonLines(ref mut common_lines) = self.buffer {
             common_lines.push(common_line);
         } else {
             self.flush_buffer();
-            self.buffer = Buffer::CommonLineBuffer(vec![common_line]);
+            self.buffer = Buffer::CommonLines(vec![common_line]);
         }
     }
 
@@ -229,7 +229,7 @@ impl<'a> Display for BufferedSummary<'a> {
 
 enum Buffer<'a> {
     Empty,
-    CommonLineBuffer(Vec<&'a str>),
+    CommonLines(Vec<&'a str>),
     ExtraActualLineChunk(&'a str),
     ExtraExpectedLineChunk(&'a str),
 }
@@ -238,7 +238,7 @@ impl<'a> Buffer<'a> {
     fn flush(&mut self, summary: &mut SummaryBuilder) {
         match self {
             Buffer::Empty => {}
-            Buffer::CommonLineBuffer(common_lines) => {
+            Buffer::CommonLines(common_lines) => {
                 Self::flush_common_lines(std::mem::take(common_lines), summary);
             }
             Buffer::ExtraActualLineChunk(extra_actual) => {


### PR DESCRIPTION
The warning was:

```
warning: variant name ends with the enum's name
   --> googletest/src/matcher_support/summarize_diff.rs:232:5
    |
232 |     CommonLineBuffer(Vec<&'a str>),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names
    = note: `#[warn(clippy::enum_variant_names)]` on by default
```