### PR TITLE
Support different binding mode in field!, property!, and matches_pattern!

### DIFF
--- a/googletest/src/matchers/matches_pattern.rs
+++ b/googletest/src/matchers/matches_pattern.rs
@@ -37,9 +37,9 @@
 ///     a_field: "Something to believe in".into(),
 ///     another_field: "Something else".into()
 /// };
-/// verify_that!(my_struct, matches_pattern!(&MyStruct {
-///     a_field: ref starts_with("Something"),
-///     another_field: ref ends_with("else"),
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     a_field: starts_with("Something"),
+///     another_field: ends_with("else"),
 /// }))
 /// #     .unwrap();
 /// ```
@@ -59,8 +59,8 @@
 /// #     a_field: "Something to believe in".into(),
 /// #     another_field: "Something else".into()
 /// # };
-/// verify_that!(my_struct, matches_pattern!(&MyStruct {
-///     a_field: ref starts_with("Something"),
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     a_field: starts_with("Something"),
 ///     // another_field is missing, so it may be anything.
 /// }))
 /// #     .unwrap();
@@ -83,9 +83,9 @@
 /// let my_struct = MyStruct {
 ///     a_nested_struct: MyInnerStruct { a_field: "Something to believe in".into() },
 /// };
-/// verify_that!(my_struct, matches_pattern!(&MyStruct {
-///      a_nested_struct: ref matches_pattern!(&MyInnerStruct {
-///         a_field: ref starts_with("Something"),
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///      a_nested_struct: matches_pattern!(MyInnerStruct {
+///         a_field: starts_with("Something"),
 ///     }),
 /// }))
 /// #     .unwrap();
@@ -109,9 +109,9 @@
 /// # let my_struct = MyStruct {
 /// #     a_nested_struct: MyInnerStruct { a_field: "Something to believe in".into() },
 /// # };
-/// verify_that!(my_struct, matches_pattern!(&MyStruct {
-///     a_nested_struct: ref pat!(&MyInnerStruct {
-///         a_field: ref starts_with("Something"),
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     a_nested_struct: pat!(MyInnerStruct {
+///         a_field: starts_with("Something"),
 ///     }),
 /// }))
 /// #     .unwrap();
@@ -132,8 +132,8 @@
 /// }
 ///
 /// let my_struct = MyStruct { a_field: "Something to believe in".into() };
-/// verify_that!(my_struct, matches_pattern!(&MyStruct {
-///     get_a_field(): ref starts_with("Something"),
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     get_a_field(): starts_with("Something"),
 /// }))
 /// #     .unwrap();
 /// ```
@@ -143,7 +143,7 @@
 /// failure, it will be invoked a second time, with the assertion failure output
 /// reflecting the *second* invocation.
 ///
-/// These may also include extra parameters you pass in:
+/// These may also include extra litteral parameters you pass in:
 ///
 /// ```
 /// # use googletest::prelude::*;
@@ -163,7 +163,7 @@
 /// #     .unwrap();
 /// ```
 ///
-/// If the method returns a non-`Copy` type, precede it with a `ref` to bind the
+/// You can precede both field and property matchers with a `ref` to match the
 /// result by reference:
 ///
 /// ```
@@ -180,6 +180,28 @@
 /// # let my_struct = MyStruct { a_field: "Something to believe in".into() };
 /// verify_that!(my_struct, matches_pattern!(&MyStruct {
 ///     get_a_field_ref(): ref starts_with("Something"),
+/// }))
+/// #    .unwrap();
+/// ```
+///
+/// Note that if the `actual` is of type `&ActualT` and the pattern type is
+/// `ActualT`, this is automatically performed. This behavior is similar to the
+/// reference binding mode in pattern matching.
+///
+/// ```
+/// # use googletest::prelude::*;
+/// # #[derive(Debug)]
+/// # struct MyStruct {
+/// #     a_field: String,
+/// # }
+/// #
+/// impl MyStruct {
+///     fn get_a_field_ref(&self) -> String { self.a_field.clone() }
+/// }
+///
+/// # let my_struct = MyStruct { a_field: "Something to believe in".into() };
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     get_a_field_ref(): starts_with("Something"),
 /// }))
 /// #    .unwrap();
 /// ```

--- a/googletest/src/matchers/mod.rs
+++ b/googletest/src/matchers/mod.rs
@@ -108,7 +108,7 @@ pub mod __internal_unstable_do_not_depend_on_these {
     pub use super::conjunction_matcher::ConjunctionMatcher;
     pub use super::disjunction_matcher::DisjunctionMatcher;
     pub use super::elements_are_matcher::internal::ElementsAre;
-    pub use super::field_matcher::internal::{field_matcher, field_ref_matcher};
+    pub use super::field_matcher::internal::field_matcher;
     pub use super::is_matcher::is;
     pub use super::pointwise_matcher::internal::PointwiseMatcher;
     pub use super::property_matcher::internal::{property_matcher, property_ref_matcher};

--- a/googletest/tests/field_matcher_test.rs
+++ b/googletest/tests/field_matcher_test.rs
@@ -216,3 +216,13 @@ fn matches_struct_copy_to_ref() -> Result<()> {
     // test case is not necessary.
     Ok(())
 }
+
+#[test]
+fn matches_struct_ref_to_ref_binding_mode() -> Result<()> {
+    #[derive(Debug)]
+    struct Strukt {
+        a_field: String,
+    }
+
+    verify_that!(Strukt { a_field: "32".into() }, field!(Strukt.a_field, eq("32")))
+}

--- a/googletest/tests/matches_pattern_test.rs
+++ b/googletest/tests/matches_pattern_test.rs
@@ -109,6 +109,35 @@ fn matches_struct_containing_nested_struct_with_field() -> Result<()> {
 }
 
 #[test]
+fn matches_struct_containing_nested_struct_with_field_with_binding_mode() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_nested_struct: ANestedStruct,
+    }
+    #[derive(Debug)]
+    struct ANestedStruct {
+        a_field: u32,
+    }
+    let actual = AStruct { a_nested_struct: ANestedStruct { a_field: 123 } };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { a_nested_struct: pat!(ANestedStruct { a_field: eq(&123) }) })
+    )
+}
+
+#[test]
+fn matches_struct_containing_non_copy_field_binding_mode() -> Result<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_string: String,
+    }
+    let actual = AStruct { a_string: "123".into() };
+
+    verify_that!(actual, matches_pattern!(AStruct { a_string: eq("123") }))
+}
+
+#[test]
 fn has_correct_assertion_failure_message_for_single_field() -> Result<()> {
     #[derive(Debug)]
     struct AStruct {

--- a/googletest/tests/property_matcher_test.rs
+++ b/googletest/tests/property_matcher_test.rs
@@ -51,14 +51,6 @@ fn matches_struct_with_matching_property_with_parameters() -> Result<()> {
 }
 
 #[test]
-fn matches_struct_with_matching_property_with_captured_arguments() -> Result<()> {
-    let value = SomeStruct { a_property: 10 };
-    let arg1 = 2;
-    let arg2 = 3;
-    verify_that!(value, property!(&SomeStruct.add_product_to_field(arg1, arg2), eq(16)))
-}
-
-#[test]
 fn matches_struct_with_matching_property_with_parameters_with_trailing_comma() -> Result<()> {
     let value = SomeStruct { a_property: 10 };
     verify_that!(value, property!(&SomeStruct.add_product_to_field(2, 3,), eq(16)))
@@ -144,6 +136,26 @@ fn explains_mismatch_referencing_explanation_of_inner_matcher() -> Result<()> {
     let value = SomeStruct { a_property: 2 };
     let result =
         verify_that!(value, property!(&SomeStruct.get_a_collection(), ref container_eq([1])));
+
+    verify_that!(
+        result,
+        err(displays_as(contains_substring(
+            "whose property `get_a_collection()` is `[]`, which is missing the element 1"
+        )))
+    )
+}
+
+#[test]
+fn explains_mismatch_referencing_explanation_of_inner_matcher_binding_mode() -> Result<()> {
+    #[derive(Debug)]
+    struct SomeStruct;
+    impl SomeStruct {
+        fn get_a_collection(&self) -> Vec<u32> {
+            vec![]
+        }
+    }
+    let result =
+        verify_that!(SomeStruct, property!(SomeStruct.get_a_collection(), container_eq([1])));
 
     verify_that!(
         result,
@@ -252,4 +264,17 @@ fn matches_ref_to_copy() -> Result<()> {
     }
 
     verify_that!(Struct, property!(&Struct.property(), eq(32)))
+}
+
+#[test]
+fn matches_ref_to_ref_with_binding_mode() -> Result<()> {
+    #[derive(Debug)]
+    struct Struct;
+    impl Struct {
+        fn property(&self) -> String {
+            "something".into()
+        }
+    }
+
+    verify_that!(Struct, property!(Struct.property(), eq("something")))
 }


### PR DESCRIPTION
Support `Matcher<T>` and `Matcher<&T>` in the matcher `field!` `property!` and `matches_pattern!`. This simulates the [reference binding mode](https://doc.rust-lang.org/reference/patterns.html#binding-modes) of Rust pattern matching.

There may be some limitations regarding the usage of argument capture in `property!`, but this feature had problems and should be handled by the `predicate` matchers or a new matcher accepting both a mapping closure and a matcher on the value returned, similar to C++ `ResultOf`.