### PR TITLE
Fix pattern matching with reference pattern.

### DIFF
--- a/googletest/src/matchers/mod.rs
+++ b/googletest/src/matchers/mod.rs
@@ -110,6 +110,7 @@ pub mod __internal_unstable_do_not_depend_on_these {
     pub use super::elements_are_matcher::internal::ElementsAre;
     pub use super::field_matcher::internal::field_matcher;
     pub use super::is_matcher::is;
+    pub use super::matches_pattern::internal::pattern_only;
     pub use super::pointwise_matcher::internal::PointwiseMatcher;
     pub use super::property_matcher::internal::{property_matcher, property_ref_matcher};
     pub use super::unordered_elements_are_matcher::internal::{

--- a/googletest/src/matchers/predicate_matcher.rs
+++ b/googletest/src/matchers/predicate_matcher.rs
@@ -36,12 +36,7 @@ use std::fmt::Debug;
 /// the closure argument, it is likely that it won't.
 /// See <https://github.com/rust-lang/rust/issues/12679> for update on this issue.
 /// This is easily fixed by explicitly declaring the type of the argument
-pub fn predicate<T: Debug + Copy, P>(
-    predicate: P,
-) -> PredicateMatcher<P, NoDescription, NoDescription>
-where
-    P: Fn(T) -> bool,
-{
+pub fn predicate<P>(predicate: P) -> PredicateMatcher<P, NoDescription, NoDescription> {
     PredicateMatcher {
         predicate,
         positive_description: NoDescription,

--- a/googletest/tests/composition_test.rs
+++ b/googletest/tests/composition_test.rs
@@ -69,3 +69,118 @@ fn elements_are_works_as_inner_matcher() -> Result<()> {
 fn tuple_works_as_inner_matcher() -> Result<()> {
     verify_that!(vec![(123,)], elements_are![(eq(&123),)])
 }
+
+#[test]
+fn matches_struct_with_method_returning_option_of_non_copy_value() -> Result<()> {
+    #[derive(Debug)]
+    struct AnInnerStruct;
+
+    #[derive(Debug)]
+    struct AStruct;
+
+    impl AStruct {
+        fn get_value(&self) -> Option<AnInnerStruct> {
+            Some(AnInnerStruct)
+        }
+    }
+
+    verify_that!(
+        AStruct,
+        matches_pattern!(&AStruct {
+            get_value(): ref some(matches_pattern!(&AnInnerStruct))
+        })
+    )
+}
+
+#[test]
+fn matches_struct_with_method_returning_option_of_non_copy_enum() -> Result<()> {
+    #[derive(Debug)]
+    enum AnInnerStruct {
+        ThisCase,
+        #[allow(unused)]
+        ThatCase,
+    }
+    #[derive(Debug)]
+    struct AStruct;
+    impl AStruct {
+        fn get_value(&self) -> Option<AnInnerStruct> {
+            Some(AnInnerStruct::ThisCase)
+        }
+    }
+
+    verify_that!(
+        AStruct,
+        matches_pattern!(&AStruct {
+            get_value(): ref some(matches_pattern!(&AnInnerStruct::ThisCase))
+        })
+    )
+}
+
+#[test]
+fn matches_struct_with_method_returning_option_ref_binding_mode() -> Result<()> {
+    #[derive(Debug)]
+    struct AnInnerStruct;
+    #[derive(Debug)]
+    struct AStruct;
+    impl AStruct {
+        fn get_value(&self) -> Option<AnInnerStruct> {
+            Some(AnInnerStruct)
+        }
+    }
+
+    verify_that!(
+        AStruct,
+        matches_pattern!(AStruct {
+            get_value(): some(matches_pattern!(AnInnerStruct))
+        })
+    )
+}
+
+#[test]
+fn matches_struct_with_method_returning_option_enum_ref_binding_mode() -> Result<()> {
+    #[derive(Debug)]
+    enum AnInnerStruct {
+        ThisCase,
+        #[allow(unused)]
+        ThatCase,
+    }
+    #[derive(Debug)]
+    struct AStruct;
+    impl AStruct {
+        fn get_value(&self) -> Option<AnInnerStruct> {
+            Some(AnInnerStruct::ThisCase)
+        }
+    }
+
+    verify_that!(
+        AStruct,
+        matches_pattern!(AStruct {
+            get_value(): some(matches_pattern!(AnInnerStruct::ThisCase))
+        })
+    )
+}
+
+#[test]
+fn matches_struct_with_property_against_predicate() -> Result<()> {
+    #[derive(Debug)]
+    enum AnInnerStruct {
+        ThisCase,
+        #[allow(unused)]
+        ThatCase,
+    }
+
+    #[derive(Debug)]
+    struct AStruct;
+    impl AStruct {
+        fn get_value(&self) -> AnInnerStruct {
+            AnInnerStruct::ThisCase
+        }
+    }
+
+    verify_that!(
+        AStruct,
+        matches_pattern!(AStruct {
+            get_value(): predicate(|_: &_| true)
+        })
+    )
+}

--- a/googletest/tests/matches_pattern_test.rs
+++ b/googletest/tests/matches_pattern_test.rs
@@ -488,6 +488,28 @@ fn matches_enum_without_field() -> Result<()> {
 }
 
 #[test]
+fn matches_enum_without_field_ref_binding_mode() -> Result<()> {
+    #[derive(Debug)]
+    enum AnEnum {
+        A,
+    }
+    let actual = AnEnum::A;
+
+    verify_that!(actual, matches_pattern!(AnEnum::A))
+}
+
+#[test]
+fn matches_enum_without_field_copy() -> Result<()> {
+    #[derive(Debug, Clone, Copy)]
+    enum AnEnum {
+        A,
+    }
+    let actual = AnEnum::A;
+
+    verify_that!(actual, matches_pattern!(AnEnum::A))
+}
+
+#[test]
 fn generates_correct_failure_output_when_enum_variant_without_field_is_not_matched() -> Result<()> {
     #[derive(Debug)]
     enum AnEnum {


### PR DESCRIPTION
`matches_pattern!` was not working properly when matching against a reference pattern without field nor property as it was not general enough (the input type is chosen and stick a specific lifetime, when a general lifetime is possible). This can be the case with composite matchers requiring their inner matcher to accept reference with any lifetime.

Also update the `predicate` matcher to produce if possible matchers of any lifetime.

Fix #385 