### PR TITLE
Add auto-ref eq in field! and property!.

### DIFF
--- a/googletest/src/matcher_support/auto_ref_eq.rs
+++ b/googletest/src/matcher_support/auto_ref_eq.rs
@@ -1,0 +1,97 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![doc(hidden)]
+
+/// Auto-ref macro that wrap the expression with `eq(...)` if the expression is
+/// not a matcher.
+///
+/// This is useful to let users pass expected value to macro matchers like
+/// `field!` and `property!`.
+///`
+/// **For internal use only. API stablility is not guaranteed!**
+/// If you are interested in using it in your matcher, please file an issue to
+/// stabilize this.
+#[macro_export]
+macro_rules! __auto_ref_eq {
+    ($e:expr) => {{
+        #[allow(unused_imports)]
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::{
+            ExpectedKind, MatcherKind,
+        };
+        match $e {
+            expected => (&expected).kind().new(expected),
+        }
+    }};
+}
+
+// This reimplements the pattern presented in
+// https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md
+pub mod internal {
+    use crate::{
+        matcher::MatcherBase,
+        matchers::{eq, EqMatcher},
+    };
+
+    pub struct MatcherTag;
+
+    pub trait MatcherKind {
+        #[inline]
+        fn kind(&self) -> MatcherTag {
+            MatcherTag
+        }
+    }
+
+    impl<M: MatcherBase> MatcherKind for M {}
+
+    impl MatcherTag {
+        #[inline]
+        pub fn new<M>(self, matcher: M) -> M {
+            matcher
+        }
+    }
+
+    pub struct ExpectedTag;
+
+    pub trait ExpectedKind {
+        #[inline]
+        fn kind(&self) -> ExpectedTag {
+            ExpectedTag
+        }
+    }
+
+    impl<T> ExpectedKind for &T {}
+
+    impl ExpectedTag {
+        #[inline]
+        pub fn new<T>(self, expected: T) -> EqMatcher<T> {
+            eq(expected)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn auto_ref_matcher() -> Result<()> {
+        verify_that!(123, __auto_ref_eq!(ge(9)))
+    }
+
+    #[test]
+    fn auto_ref_expected() -> Result<()> {
+        verify_that!(123, __auto_ref_eq!(123))
+    }
+}

--- a/googletest/src/matcher_support/mod.rs
+++ b/googletest/src/matcher_support/mod.rs
@@ -18,7 +18,13 @@
 //! these facilities could be useful to downstream users writing custom
 //! matchers.
 
+mod auto_ref_eq;
 pub(crate) mod count_elements;
 pub(crate) mod edit_distance;
 pub(crate) mod summarize_diff;
 pub(crate) mod zipped_iterator;
+
+pub mod __internal_unstable_do_not_depend_on_these {
+    pub use super::auto_ref_eq::internal::{ExpectedKind, MatcherKind};
+    pub use crate::__auto_ref_eq as auto_ref_eq;
+}

--- a/googletest/src/matchers/field_matcher.rs
+++ b/googletest/src/matchers/field_matcher.rs
@@ -89,6 +89,21 @@
 /// # should_pass().unwrap();
 /// ```
 ///
+/// If the inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+/// #[derive(Debug)]
+/// struct IntField {
+///   int: i32
+/// }
+/// # fn should_pass() -> Result<()> {
+/// verify_that!(IntField{int: 32}, field!(&IntField.int, 32))?;
+/// #     Ok(())
+/// # }
+/// # should_pass().unwrap();
+/// ```
+///
 /// Nested structures are *not supported*, however:
 ///
 /// ```compile_fail
@@ -183,6 +198,7 @@ macro_rules! __field {
 macro_rules! field_internal {
     (&$($t:ident)::+.$field:tt, ref $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
         field_matcher(
             |o: &_| {
                 match o {
@@ -195,10 +211,11 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            $m)
+            auto_ref_eq!($m))
     }};
     (&$($t:ident)::+.$field:tt, $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
         field_matcher(
             |o: &&_| {
                 match o {
@@ -211,10 +228,11 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            $m)
+            auto_ref_eq!($m))
     }};
     ($($t:ident)::+.$field:tt, $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
         field_matcher(
             |o: &_| {
                 match o {
@@ -227,7 +245,7 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            $m)
+            auto_ref_eq!($m))
     }};
 }
 

--- a/googletest/src/matchers/matches_pattern.rs
+++ b/googletest/src/matchers/matches_pattern.rs
@@ -138,6 +138,27 @@
 /// #     .unwrap();
 /// ```
 ///
+/// If an inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+/// #[derive(Debug)]
+/// struct MyStruct {
+///     a_field: String,
+///     another_field: String,
+/// }
+///
+/// let my_struct = MyStruct {
+///     a_field: "this".into(),
+///     another_field: "that".into()
+/// };
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     a_field: "this",
+///     another_field: "that",
+/// }))
+/// #     .unwrap();
+/// ```
+///
 /// **Important**: The method should be pure function with a deterministic
 /// output and no side effects. In particular, in the event of an assertion
 /// failure, it will be invoked a second time, with the assertion failure output

--- a/googletest/src/matchers/property_matcher.rs
+++ b/googletest/src/matchers/property_matcher.rs
@@ -39,6 +39,25 @@
 /// #    .unwrap();
 /// ```
 ///
+///
+/// If the inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+/// #[derive(Debug)]
+/// pub struct MyStruct {
+///     a_field: u32,
+/// }
+///
+/// impl MyStruct {
+///     pub fn get_a_field(&self) -> u32 { self.a_field }
+/// }
+///
+/// let value = vec![MyStruct { a_field: 100 }];
+/// verify_that!(value, contains(property!(&MyStruct.get_a_field(), 100)))
+/// #    .unwrap();
+/// ```
+///
 /// **Important**: The method should be pure function with a deterministic
 /// output and no side effects. In particular, in the event of an assertion
 /// failure, it will be invoked a second time, with the assertion failure output
@@ -160,31 +179,35 @@ macro_rules! property_internal {
 
     (&$($t:ident)::+.$method:tt($($argument:tt),* $(,)?), ref $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
         property_ref_matcher(
             |o: &$($t)::+| $($t)::+::$method(o, $($argument),*),
             &stringify!($method($($argument),*)),
-            $m)
+            auto_ref_eq!($m))
     }};
     ($($t:ident)::+.$method:tt($($argument:tt),* $(,)?), ref $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
         property_ref_matcher(
             |o: $($t)::+| $($t)::+::$method(o, $($argument),*),
             &stringify!($method($($argument),*)),
-            $m)
+            auto_ref_eq!($m))
     }};
     (& $($t:ident)::+.$method:tt($($argument:tt),* $(,)?), $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_matcher;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
         property_matcher(
             |o: &&$($t)::+| o.$method($($argument),*),
             &stringify!($method($($argument),*)),
-            $m)
+            auto_ref_eq!($m))
     }};
     ($($t:ident)::+.$method:tt($($argument:tt),* $(,)?), $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_matcher;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
         property_matcher(
             |o: &$($t)::+| o.$method($($argument),*),
             &stringify!($method($($argument),*)),
-            $m)
+            auto_ref_eq!($m))
     }};
 }
 

--- a/googletest/tests/field_matcher_test.rs
+++ b/googletest/tests/field_matcher_test.rs
@@ -227,3 +227,25 @@ fn matches_struct_ref_to_ref_binding_mode() -> Result<()> {
 
     verify_that!(Strukt { a_field: "32".into() }, field!(Strukt.a_field, eq("32")))
 }
+
+#[test]
+fn matches_struct_with_auto_ref_eq() -> Result<()> {
+    #[derive(Debug)]
+    struct Strukt {
+        a_field: String,
+    }
+
+    verify_that!(Strukt { a_field: "32".into() }, field!(Strukt.a_field, "32"))
+}
+
+#[test]
+fn matches_enum_with_auto_ref_eq() -> Result<()> {
+    #[derive(Debug)]
+    enum Enum {
+        Str(String),
+        #[allow(unused)]
+        Int(i32),
+    }
+
+    verify_that!(Enum::Str("32".into()), field!(Enum::Str.0, "32"))
+}

--- a/googletest/tests/matches_pattern_test.rs
+++ b/googletest/tests/matches_pattern_test.rs
@@ -1799,3 +1799,18 @@ fn matches_copy_struct_property_non_copy() -> Result<()> {
 
     verify_that!(actual, matches_pattern!(AStruct { prop(): ref eq("123") }))
 }
+
+#[test]
+fn matches_struct_auto_ref_eq() -> Result<()> {
+    #[derive(Debug, Clone)]
+    struct AStruct {
+        int: i32,
+        string: String,
+        option: Option<i32>,
+    }
+
+    verify_that!(
+        AStruct { int: 123, string: "123".into(), option: Some(123) },
+        matches_pattern!(&AStruct { int: 123, string: ref "123", option: Some(123) })
+    )
+}

--- a/googletest/tests/property_matcher_test.rs
+++ b/googletest/tests/property_matcher_test.rs
@@ -278,3 +278,16 @@ fn matches_ref_to_ref_with_binding_mode() -> Result<()> {
 
     verify_that!(Struct, property!(Struct.property(), eq("something")))
 }
+
+#[test]
+fn matches_property_auto_ref_eq() -> Result<()> {
+    #[derive(Debug)]
+    struct Struct;
+    impl Struct {
+        fn property(&self) -> String {
+            "something".into()
+        }
+    }
+
+    verify_that!(Struct, property!(Struct.property(), "something"))
+}


### PR DESCRIPTION
This PR let the user remove `eq(...)` in `field!(...)`, `property!(...)` and `matches_pattern!(...)`.

Basically, `field!(MyStruct.my_field, eq(123))` is equivalent to `field!(MyStruct.my_field, 123)`. This is done through auto-ref specialization, as a macro is able to "inject" `eq(...)` if the second parameter of `field!(...)` is not a `MatcherBase`.