### PR TITLE
Save color configuration in a thread local variable

### DIFF
--- a/googletest/Cargo.toml
+++ b/googletest/Cargo.toml
@@ -41,4 +41,3 @@ rustversion = "1.0.14"
 [dev-dependencies]
 indoc = "2"
 quickcheck = "1.0.3"
-serial_test = "2.0.0"

--- a/googletest/src/matchers/display_matcher.rs
+++ b/googletest/src/matchers/display_matcher.rs
@@ -68,7 +68,6 @@ impl<T: Debug + Display + Copy, InnerMatcher: for<'a> Matcher<&'a str>> Matcher<
 mod tests {
     use crate::prelude::*;
     use indoc::indoc;
-    use serial_test::parallel;
     use std::fmt::{Debug, Display, Error, Formatter};
 
     #[test]
@@ -103,7 +102,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn display_displays_error_message_with_explanation_from_inner_matcher() -> Result<()> {
         let result = verify_that!("123\n234", displays_as(eq("123\n345")));
 

--- a/googletest/src/matchers/eq_matcher.rs
+++ b/googletest/src/matchers/eq_matcher.rs
@@ -135,7 +135,6 @@ fn to_display_output(string: &str) -> Option<String> {
 mod tests {
     use crate::prelude::*;
     use indoc::indoc;
-    use serial_test::parallel;
 
     #[test]
     fn eq_matches_string_reference_with_string_reference() -> Result<()> {
@@ -160,7 +159,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn eq_struct_debug_diff() -> Result<()> {
         #[derive(Debug, PartialEq)]
         struct Strukt {
@@ -190,7 +188,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn eq_vec_debug_diff() -> Result<()> {
         let result = verify_that!(vec![1, 2, 3], eq(&vec![1, 3, 4]));
         verify_that!(
@@ -213,7 +210,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn eq_vec_debug_diff_length_mismatch() -> Result<()> {
         let result = verify_that!(vec![1, 2, 3, 4, 5], eq(&vec![1, 3, 5]));
         verify_that!(
@@ -237,7 +233,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn eq_debug_diff_common_lines_omitted() -> Result<()> {
         let result = verify_that!((1..50).collect::<Vec<_>>(), eq(&(3..52).collect::<Vec<_>>()));
         verify_that!(
@@ -262,7 +257,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn eq_debug_diff_5_common_lines_not_omitted() -> Result<()> {
         let result = verify_that!((1..8).collect::<Vec<_>>(), eq(&(3..10).collect::<Vec<_>>()));
         verify_that!(
@@ -287,7 +281,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn eq_debug_diff_start_common_lines_omitted() -> Result<()> {
         let result = verify_that!((1..50).collect::<Vec<_>>(), eq(&(1..52).collect::<Vec<_>>()));
         verify_that!(
@@ -309,7 +302,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn eq_debug_diff_end_common_lines_omitted() -> Result<()> {
         let result = verify_that!((1..52).collect::<Vec<_>>(), eq(&(3..52).collect::<Vec<_>>()));
         verify_that!(
@@ -348,7 +340,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn match_explanation_contains_diff_of_strings_if_more_than_one_line() -> Result<()> {
         let result = verify_that!(
             indoc!(

--- a/googletest/src/matchers/str_matcher.rs
+++ b/googletest/src/matchers/str_matcher.rs
@@ -574,7 +574,6 @@ mod tests {
     use crate::matcher::MatcherResult;
     use crate::prelude::*;
     use indoc::indoc;
-    use serial_test::parallel;
 
     #[test]
     fn matches_string_reference_with_equal_string_reference() -> Result<()> {
@@ -953,7 +952,6 @@ mod tests {
     }
 
     #[test]
-    #[parallel]
     fn match_explanation_for_starts_with_ignores_trailing_lines_in_actual_string() -> Result<()> {
         let result = verify_that!(
             indoc!(


### PR DESCRIPTION
This has three advantages:
* Avoid recomputing this configuration multiple times. Thread local variables are instantiated lazily, so it is only a positive.
* Remove dependency on `serial_test`
* Remove usage in unit tests of [`std::env::set_var`](https://doc.rust-lang.org/std/env/fn.set_var.html#safety) and [`std::env::remove_var`](https://doc.rust-lang.org/std/env/fn.remove_var.html#safety), which will eventually become unsafe [rust#27970](https://github.com/rust-lang/rust/issues/27970).