### PR TITLE
Fix auto_eq to work with &Matcher.

### DIFF
--- a/googletest/src/matcher_support/mod.rs
+++ b/googletest/src/matcher_support/mod.rs
@@ -18,13 +18,13 @@
 //! these facilities could be useful to downstream users writing custom
 //! matchers.
 
-mod auto_ref_eq;
+mod auto_eq;
 pub(crate) mod count_elements;
 pub(crate) mod edit_distance;
 pub(crate) mod summarize_diff;
 pub(crate) mod zipped_iterator;
 
 pub mod __internal_unstable_do_not_depend_on_these {
-    pub use super::auto_ref_eq::internal::{ExpectedKind, MatcherKind};
-    pub use crate::__auto_ref_eq as auto_ref_eq;
+    pub use super::auto_eq::internal::{ExpectedKind, Wrapper};
+    pub use crate::__auto_eq as auto_eq;
 }

--- a/googletest/src/matchers/field_matcher.rs
+++ b/googletest/src/matchers/field_matcher.rs
@@ -198,7 +198,7 @@ macro_rules! __field {
 macro_rules! field_internal {
     (&$($t:ident)::+.$field:tt, ref $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         field_matcher(
             |o: &_| {
                 match o {
@@ -211,11 +211,11 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            auto_ref_eq!($m))
+            auto_eq!($m))
     }};
     (&$($t:ident)::+.$field:tt, $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         field_matcher(
             |o: &&_| {
                 match o {
@@ -228,11 +228,11 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            auto_ref_eq!($m))
+            auto_eq!($m))
     }};
     ($($t:ident)::+.$field:tt, $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         field_matcher(
             |o: &_| {
                 match o {
@@ -245,7 +245,7 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            auto_ref_eq!($m))
+            auto_eq!($m))
     }};
 }
 

--- a/googletest/src/matchers/property_matcher.rs
+++ b/googletest/src/matchers/property_matcher.rs
@@ -179,35 +179,35 @@ macro_rules! property_internal {
 
     (&$($t:ident)::+.$method:tt($($argument:tt),* $(,)?), ref $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         property_ref_matcher(
             |o: &$($t)::+| $($t)::+::$method(o, $($argument),*),
             &stringify!($method($($argument),*)),
-            auto_ref_eq!($m))
+            auto_eq!($m))
     }};
     ($($t:ident)::+.$method:tt($($argument:tt),* $(,)?), ref $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         property_ref_matcher(
             |o: $($t)::+| $($t)::+::$method(o, $($argument),*),
             &stringify!($method($($argument),*)),
-            auto_ref_eq!($m))
+            auto_eq!($m))
     }};
     (& $($t:ident)::+.$method:tt($($argument:tt),* $(,)?), $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         property_matcher(
             |o: &&$($t)::+| o.$method($($argument),*),
             &stringify!($method($($argument),*)),
-            auto_ref_eq!($m))
+            auto_eq!($m))
     }};
     ($($t:ident)::+.$method:tt($($argument:tt),* $(,)?), $m:expr) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_ref_eq;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         property_matcher(
             |o: &$($t)::+| o.$method($($argument),*),
             &stringify!($method($($argument),*)),
-            auto_ref_eq!($m))
+            auto_eq!($m))
     }};
 }
 

--- a/googletest/tests/field_matcher_test.rs
+++ b/googletest/tests/field_matcher_test.rs
@@ -229,7 +229,7 @@ fn matches_struct_ref_to_ref_binding_mode() -> Result<()> {
 }
 
 #[test]
-fn matches_struct_with_auto_ref_eq() -> Result<()> {
+fn matches_struct_with_auto_eq() -> Result<()> {
     #[derive(Debug)]
     struct Strukt {
         a_field: String,
@@ -239,7 +239,7 @@ fn matches_struct_with_auto_ref_eq() -> Result<()> {
 }
 
 #[test]
-fn matches_enum_with_auto_ref_eq() -> Result<()> {
+fn matches_enum_with_auto_eq() -> Result<()> {
     #[derive(Debug)]
     enum Enum {
         Str(String),
@@ -248,4 +248,17 @@ fn matches_enum_with_auto_ref_eq() -> Result<()> {
     }
 
     verify_that!(Enum::Str("32".into()), field!(Enum::Str.0, "32"))
+}
+
+#[test]
+fn matches_enum_with_auto_eq_with_wrapper() -> Result<()> {
+    #[derive(Debug)]
+    struct Wrapper<I> {
+        wrapped: I,
+    }
+
+    verify_that!(
+        Wrapper { wrapped: Wrapper { wrapped: 23 } },
+        field!(Wrapper.wrapped, field!(Wrapper.wrapped, &23))
+    )
 }

--- a/googletest/tests/matches_pattern_test.rs
+++ b/googletest/tests/matches_pattern_test.rs
@@ -1801,7 +1801,7 @@ fn matches_copy_struct_property_non_copy() -> Result<()> {
 }
 
 #[test]
-fn matches_struct_auto_ref_eq() -> Result<()> {
+fn matches_struct_auto_eq() -> Result<()> {
     #[derive(Debug, Clone)]
     struct AStruct {
         int: i32,

--- a/googletest/tests/property_matcher_test.rs
+++ b/googletest/tests/property_matcher_test.rs
@@ -285,7 +285,7 @@ fn matches_ref_to_ref_with_binding_mode() -> Result<()> {
 }
 
 #[test]
-fn matches_property_auto_ref_eq() -> Result<()> {
+fn matches_property_auto_eq() -> Result<()> {
     #[derive(Debug)]
     struct Struct;
     impl Struct {


### PR DESCRIPTION
Autoref specialization was not working with `&Matcher` (which also implement `Matcher`). Inherent specialization seems to fix this issue.