### PR TITLE
Remove symbol imports in macro.

### DIFF
--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -122,7 +122,7 @@
 macro_rules! verify_that {
     ($actual:expr, [$($expecteds:expr),+ $(,)?]) => {
         {
-            use $crate::assertions::internal::Subject;
+            use $crate::assertions::internal::Subject as _;
             $actual.check(
                 $crate::matchers::elements_are![$($expecteds),+],
                 stringify!($actual),
@@ -131,7 +131,7 @@ macro_rules! verify_that {
     };
     ($actual:expr, {$($expecteds:expr),+ $(,)?}) => {
         {
-            use $crate::assertions::internal::Subject;
+            use $crate::assertions::internal::Subject as  _;
             $actual.check(
                 $crate::matchers::unordered_elements_are![$($expecteds),+],
                 stringify!($actual),
@@ -140,7 +140,7 @@ macro_rules! verify_that {
     };
     ($actual:expr, $expected:expr $(,)?) => {
         {
-            use $crate::assertions::internal::Subject;
+            use $crate::assertions::internal::Subject as  _;
             $actual.check(
                 $expected,
                 stringify!($actual),
@@ -358,7 +358,7 @@ macro_rules! succeed {
 #[macro_export]
 macro_rules! add_failure {
     ($($message:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         $crate::assertions::internal::create_fail_result(
             format!($($message),*),
         ).and_log_failure();
@@ -406,7 +406,7 @@ macro_rules! add_failure {
 #[macro_export]
 macro_rules! add_failure_at {
     ($file:expr, $line:expr, $column:expr, $($message:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         $crate::assertions::internal::create_fail_result(
             format!($($message),*),
         ).map_err(|e| e.with_fake_location($file, $line, $column)).and_log_failure();
@@ -444,7 +444,7 @@ macro_rules! add_failure_at {
 #[macro_export]
 macro_rules! verify_true {
     ($condition:expr) => {{
-        use $crate::assertions::internal::Subject;
+        use $crate::assertions::internal::Subject as _;
         ($condition).check($crate::matchers::eq(true), stringify!($condition))
     }};
 }
@@ -472,7 +472,7 @@ macro_rules! verify_true {
 #[macro_export]
 macro_rules! expect_true {
     ($condition:expr) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_true!($condition).and_log_failure()
     }};
 }
@@ -504,7 +504,7 @@ macro_rules! expect_true {
 #[macro_export]
 macro_rules! verify_false {
     ($condition:expr) => {{
-        use $crate::assertions::internal::Subject;
+        use $crate::assertions::internal::Subject as _;
         ($condition).check($crate::matchers::eq(false), stringify!($condition))
     }};
 }
@@ -532,7 +532,7 @@ macro_rules! verify_false {
 #[macro_export]
 macro_rules! expect_false {
     ($condition:expr) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_false!($condition).and_log_failure()
     }};
 }
@@ -622,31 +622,31 @@ macro_rules! verify_eq {
 #[macro_export]
 macro_rules! expect_eq {
     ($actual:expr, [$($expected:expr),+ $(,)?] $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_eq!($actual, [$($expected),*]).and_log_failure();
     }};
     ($actual:expr, [$($expected:expr),+ $(,)?], $($format_args:expr),* $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_eq!($actual, [$($expected),*])
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, {$($expected:expr),+ $(,)?} $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_eq!($actual, {$($expected),*}).and_log_failure();
     }};
     ($actual:expr, {$($expected:expr),+ $(,)?}, $($format_args:expr),* $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_eq!($actual, {$($expected),*})
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_eq!($actual, $expected).and_log_failure();
     }};
     ($actual:expr, $expected:expr, $($format_args:expr),* $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_eq!($actual, $expected)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
@@ -720,13 +720,13 @@ macro_rules! verify_ne {
 #[macro_export]
 macro_rules! expect_ne {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_ne!($actual, $expected)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_ne!($actual, $expected).and_log_failure();
     }};
 }
@@ -798,13 +798,13 @@ macro_rules! verify_lt {
 #[macro_export]
 macro_rules! expect_lt {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_lt!($actual, $expected)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_lt!($actual, $expected).and_log_failure();
     }};
 }
@@ -877,13 +877,13 @@ macro_rules! verify_le {
 #[macro_export]
 macro_rules! expect_le {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_le!($actual, $expected)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_le!($actual, $expected).and_log_failure();
     }};
 }
@@ -955,13 +955,13 @@ macro_rules! verify_gt {
 #[macro_export]
 macro_rules! expect_gt {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_gt!($actual, $expected)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_gt!($actual, $expected).and_log_failure();
     }};
 }
@@ -1035,13 +1035,13 @@ macro_rules! verify_ge {
 #[macro_export]
 macro_rules! expect_ge {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_ge!($actual, $expected)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_ge!($actual, $expected).and_log_failure();
     }};
 }
@@ -1130,13 +1130,13 @@ macro_rules! verify_float_eq {
 #[macro_export]
 macro_rules! expect_float_eq {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_float_eq!($actual, $expected)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_float_eq!($actual, $expected).and_log_failure();
     }};
 }
@@ -1211,13 +1211,13 @@ macro_rules! verify_near {
 #[macro_export]
 macro_rules! expect_near {
     ($actual:expr, $expected:expr, $max_abs_error:expr, $($format_args:expr),+ $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_near!($actual, $expected, $max_abs_error)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr, $max_abs_error:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         verify_near!($actual, $expected, $max_abs_error).and_log_failure();
     }};
 }
@@ -1359,7 +1359,7 @@ macro_rules! assert_pred {
 #[macro_export]
 macro_rules! expect_that {
     ($actual:expr, $expected:expr $(,)?) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         $crate::verify_that!($actual, $expected).and_log_failure();
     }};
 
@@ -1389,7 +1389,7 @@ macro_rules! expect_that {
 #[macro_export]
 macro_rules! expect_pred {
     ($($content:tt)*) => {{
-        use $crate::GoogleTestSupport;
+        use $crate::GoogleTestSupport as _;
         $crate::verify_pred!($($content)*).and_log_failure();
     }};
 }

--- a/googletest/src/matcher_support/auto_eq.rs
+++ b/googletest/src/matcher_support/auto_eq.rs
@@ -27,7 +27,7 @@
 macro_rules! __auto_eq {
     ($e:expr) => {{
         #[allow(unused_imports)]
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::ExpectedKind;
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::ExpectedKind as _;
         match $e {
             expected => {
                 $crate::matcher_support::__internal_unstable_do_not_depend_on_these::Wrapper(

--- a/googletest/src/matchers/all_matcher.rs
+++ b/googletest/src/matchers/all_matcher.rs
@@ -50,6 +50,15 @@
 /// ```
 ///
 /// Assertion failure messages are not guaranteed to be identical, however.
+///
+///  If an inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+///
+/// verify_that!(123, all![123, lt(1000), gt(100)])
+/// #     .unwrap();
+/// ```
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __all {
@@ -57,14 +66,17 @@ macro_rules! __all {
         $crate::matchers::anything()
     }} ;
     ($matcher:expr $(,)?) => {{
-        $matcher
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
+        auto_eq!($matcher)
     }};
     ($head:expr, $head2:expr $(,)?) => {{
-        $crate::matchers::__internal_unstable_do_not_depend_on_these::ConjunctionMatcher::new($head, $head2)
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::ConjunctionMatcher::new(auto_eq!($head), auto_eq!($head2))
     }};
     ($head:expr, $head2:expr, $($tail:expr),+ $(,)?) => {{
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         $crate::__all![
-            $crate::matchers::__internal_unstable_do_not_depend_on_these::ConjunctionMatcher::new($head, $head2),
+            $crate::matchers::__internal_unstable_do_not_depend_on_these::ConjunctionMatcher::new(auto_eq!($head), auto_eq!($head2)),
             $($tail),+
         ]
     }}
@@ -126,5 +138,10 @@ mod tests {
             matcher.explain_match("A string"),
             displays_as(eq("which does not start with \"Another\""))
         )
+    }
+
+    #[test]
+    fn all_with_auto_eq() -> Result<()> {
+        verify_that!(42, all![eq(42), 42, lt(100)])
     }
 }

--- a/googletest/src/matchers/any_matcher.rs
+++ b/googletest/src/matchers/any_matcher.rs
@@ -52,6 +52,15 @@
 /// ```
 ///
 /// Assertion failure messages are not guaranteed to be identical, however.
+///
+///  If an inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+///
+/// verify_that!(123, any![lt(1), 123, gt(1000)])
+/// #     .unwrap();
+/// ```
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __any {
@@ -59,14 +68,17 @@ macro_rules! __any {
         $crate::matchers::not($crate::matchers::anything())
     }} ;
     ($matcher:expr $(,)?) => {{
-        $matcher
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
+        auto_eq!($matcher)
     }};
     ($head:expr, $head2:expr $(,)?) => {{
-        $crate::matchers::__internal_unstable_do_not_depend_on_these::DisjunctionMatcher::new($head, $head2)
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::DisjunctionMatcher::new(auto_eq!($head), auto_eq!($head2))
     }};
     ($head:expr, $head2:expr, $($tail:expr),+ $(,)?) => {{
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         $crate::__any![
-            $crate::matchers::__internal_unstable_do_not_depend_on_these::DisjunctionMatcher::new($head, $head2),
+            $crate::matchers::__internal_unstable_do_not_depend_on_these::DisjunctionMatcher::new(auto_eq!($head), auto_eq!($head2)),
             $($tail),+
         ]
     }}
@@ -133,5 +145,10 @@ mod tests {
     #[test]
     fn empty_any_matcher_never_matches() -> Result<()> {
         verify_that!(123, not(any![]))
+    }
+
+    #[test]
+    fn any_with_auto_eq() -> Result<()> {
+        verify_that!(42, any![1, 2, 42, gt(123)])
     }
 }

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -87,9 +87,10 @@
 #[doc(hidden)]
 macro_rules! __elements_are {
     ($($matcher:expr),* $(,)?) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::ElementsAre;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        ElementsAre::new(vec![$(Box::new(auto_eq!($matcher))),*])
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::ElementsAre::new(
+            vec![$(Box::new(
+                $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($matcher)
+            )),*])
     }}
 }
 

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -65,6 +65,15 @@
 /// # .unwrap();
 /// ```
 ///
+///  If an inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+///
+/// verify_that!(vec![1,2,3], elements_are![&1, lt(&1000), gt(&1)])
+/// #     .unwrap();
+/// ```
+///
 /// Do not use this with unordered containers, since that will lead to flaky
 /// tests. Use
 /// [`unordered_elements_are!`][crate::matchers::unordered_elements_are]
@@ -79,7 +88,8 @@
 macro_rules! __elements_are {
     ($($matcher:expr),* $(,)?) => {{
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::ElementsAre;
-        ElementsAre::new(vec![$(Box::new($matcher)),*])
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
+        ElementsAre::new(vec![$(Box::new(auto_eq!($matcher))),*])
     }}
 }
 

--- a/googletest/src/matchers/field_matcher.rs
+++ b/googletest/src/matchers/field_matcher.rs
@@ -197,9 +197,7 @@ macro_rules! __field {
 #[macro_export]
 macro_rules! field_internal {
     (&$($t:ident)::+.$field:tt, ref $m:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        field_matcher(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher(
             |o: &_| {
                 match o {
                     &$($t)::* {$field: ref value, .. } => Some(value),
@@ -211,12 +209,10 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            auto_eq!($m))
+            $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($m))
     }};
     (&$($t:ident)::+.$field:tt, $m:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        field_matcher(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher(
             |o: &&_| {
                 match o {
                     &$($t)::* {$field: value, .. } => Some(value),
@@ -228,12 +224,10 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            auto_eq!($m))
+            $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($m))
     }};
     ($($t:ident)::+.$field:tt, $m:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        field_matcher(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::field_matcher(
             |o: &_| {
                 match o {
                     $($t)::* {$field: value, .. } => Some(value),
@@ -245,7 +239,7 @@ macro_rules! field_internal {
                 }
             },
             &stringify!($field),
-            auto_eq!($m))
+            $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($m))
     }};
 }
 

--- a/googletest/src/matchers/pointwise_matcher.rs
+++ b/googletest/src/matchers/pointwise_matcher.rs
@@ -114,13 +114,13 @@
 #[doc(hidden)]
 macro_rules! __pointwise {
     ($matcher:expr, $container:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::PointwiseMatcher;
-        PointwiseMatcher::new($container.into_iter().map($matcher).collect())
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::PointwiseMatcher::new(
+            $container.into_iter().map($matcher).collect(),
+        )
     }};
 
     ($matcher:expr, $left_container:expr, $right_container:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::PointwiseMatcher;
-        PointwiseMatcher::new(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::PointwiseMatcher::new(
             $left_container
                 .into_iter()
                 .zip($right_container.into_iter())
@@ -130,8 +130,7 @@ macro_rules! __pointwise {
     }};
 
     ($matcher:expr, $left_container:expr, $middle_container:expr, $right_container:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::PointwiseMatcher;
-        PointwiseMatcher::new(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::PointwiseMatcher::new(
             $left_container
                 .into_iter()
                 .zip($right_container.into_iter().zip($middle_container.into_iter()))

--- a/googletest/src/matchers/property_matcher.rs
+++ b/googletest/src/matchers/property_matcher.rs
@@ -178,36 +178,28 @@ macro_rules! __property {
 macro_rules! property_internal {
 
     (&$($t:ident)::+.$method:tt($($argument:tt),* $(,)?), ref $m:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        property_ref_matcher(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher(
             |o: &$($t)::+| $($t)::+::$method(o, $($argument),*),
             &stringify!($method($($argument),*)),
-            auto_eq!($m))
+            $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($m))
     }};
     ($($t:ident)::+.$method:tt($($argument:tt),* $(,)?), ref $m:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        property_ref_matcher(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::property_ref_matcher(
             |o: $($t)::+| $($t)::+::$method(o, $($argument),*),
             &stringify!($method($($argument),*)),
-            auto_eq!($m))
+            $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($m))
     }};
     (& $($t:ident)::+.$method:tt($($argument:tt),* $(,)?), $m:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        property_matcher(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::property_matcher(
             |o: &&$($t)::+| o.$method($($argument),*),
             &stringify!($method($($argument),*)),
-            auto_eq!($m))
+            $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($m))
     }};
     ($($t:ident)::+.$method:tt($($argument:tt),* $(,)?), $m:expr) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::property_matcher;
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        property_matcher(
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::property_matcher(
             |o: &$($t)::+| o.$method($($argument),*),
             &stringify!($method($($argument),*)),
-            auto_eq!($m))
+            $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($m))
     }};
 }
 

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -108,18 +108,15 @@
 #[doc(hidden)]
 macro_rules! __unordered_elements_are {
     ($(,)?) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
-            UnorderedElementsAreMatcher, Requirements
-        };
-        UnorderedElementsAreMatcher::new([], Requirements::PerfectMatch)
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::UnorderedElementsAreMatcher::new(
+            [], $crate::matchers::__internal_unstable_do_not_depend_on_these::Requirements::PerfectMatch)
     }};
 
     ($($matcher:expr),* $(,)?) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
-            UnorderedElementsAreMatcher, Requirements
-        };
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        UnorderedElementsAreMatcher::new([$(Box::new(auto_eq!($matcher))),*], Requirements::PerfectMatch)
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::UnorderedElementsAreMatcher::new(
+            [$(Box::new(
+                $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($matcher))),*],
+            $crate::matchers::__internal_unstable_do_not_depend_on_these::Requirements::PerfectMatch)
     }};
 }
 
@@ -195,18 +192,16 @@ macro_rules! __unordered_elements_are {
 #[doc(hidden)]
 macro_rules! __contains_each {
     ($(,)?) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
-            UnorderedElementsAreMatcher, Requirements
-        };
-        UnorderedElementsAreMatcher::new([], Requirements::Superset)
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::UnorderedElementsAreMatcher::new(
+            [], $crate::matchers::__internal_unstable_do_not_depend_on_these::Requirements::Superset)
     }};
 
     ($($matcher:expr),* $(,)?) => {{
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
-            UnorderedElementsAreMatcher, Requirements
-        };
-        UnorderedElementsAreMatcher::new([$(Box::new(auto_eq!($matcher))),*], Requirements::Superset)
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::UnorderedElementsAreMatcher::new(
+            [$(Box::new(
+                $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($matcher)
+            )),*],
+            $crate::matchers::__internal_unstable_do_not_depend_on_these::Requirements::Superset)
     }}
 }
 
@@ -283,18 +278,16 @@ macro_rules! __contains_each {
 #[doc(hidden)]
 macro_rules! __is_contained_in {
     ($(,)?) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
-            UnorderedElementsAreMatcher, Requirements
-        };
-        UnorderedElementsAreMatcher::new([], Requirements::Subset)
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::UnorderedElementsAreMatcher::new(
+            [], $crate::matchers::__internal_unstable_do_not_depend_on_these::Requirements::Subset)
     }};
 
     ($($matcher:expr),* $(,)?) => {{
-        use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
-            UnorderedElementsAreMatcher, Requirements
-        };
-        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
-        UnorderedElementsAreMatcher::new([$(Box::new(auto_eq!($matcher))),*], Requirements::Subset)
+        $crate::matchers::__internal_unstable_do_not_depend_on_these::UnorderedElementsAreMatcher::new(
+            [$(Box::new(
+                $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq!($matcher)
+            )),*],
+            $crate::matchers::__internal_unstable_do_not_depend_on_these::Requirements::Subset)
     }}
 }
 

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -73,6 +73,15 @@
 /// # .unwrap();
 /// ```
 ///
+///  If an inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+///
+/// verify_that!(vec![1,2,3], unordered_elements_are![lt(&2), gt(&1), &3])
+/// #     .unwrap();
+/// ```
+///
 /// The matcher proceeds in three stages:
 ///
 /// 1. It first checks whether the actual value is of the right size to possibly
@@ -109,7 +118,8 @@ macro_rules! __unordered_elements_are {
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
             UnorderedElementsAreMatcher, Requirements
         };
-        UnorderedElementsAreMatcher::new([$(Box::new($matcher)),*], Requirements::PerfectMatch)
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
+        UnorderedElementsAreMatcher::new([$(Box::new(auto_eq!($matcher))),*], Requirements::PerfectMatch)
     }};
 }
 
@@ -153,6 +163,15 @@ macro_rules! __unordered_elements_are {
 /// The actual value must be a container such as a `&Vec`, an array, or a
 /// slice. More precisely, the actual value must implement [`IntoIterator`].
 ///
+///  If an inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+///
+/// verify_that!(vec![1,2,3], contains_each![lt(&2), &3])
+/// #     .unwrap();
+/// ```
+///
 /// The matcher proceeds in three stages:
 ///
 /// 1. It first checks whether the actual value is large enough to possibly be
@@ -183,10 +202,11 @@ macro_rules! __contains_each {
     }};
 
     ($($matcher:expr),* $(,)?) => {{
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
             UnorderedElementsAreMatcher, Requirements
         };
-        UnorderedElementsAreMatcher::new([$(Box::new($matcher)),*], Requirements::Superset)
+        UnorderedElementsAreMatcher::new([$(Box::new(auto_eq!($matcher))),*], Requirements::Superset)
     }}
 }
 
@@ -231,6 +251,15 @@ macro_rules! __contains_each {
 /// The actual value must be a container such as a `&Vec`, an array, or a slice.
 /// More precisely, the actual value must implement [`IntoIterator`].
 ///
+///  If an inner matcher is `eq(...)`, it can be omitted:
+///
+/// ```
+/// # use googletest::prelude::*;
+///
+/// verify_that!(vec![1,2,3], is_contained_in![lt(&2), &3, &4, gt(&0)])
+/// #     .unwrap();
+/// ```
+///
 /// The matcher proceeds in three stages:
 ///
 /// 1. It first checks whether the actual value is too large to possibly be
@@ -264,7 +293,8 @@ macro_rules! __is_contained_in {
         use $crate::matchers::__internal_unstable_do_not_depend_on_these::{
             UnorderedElementsAreMatcher, Requirements
         };
-        UnorderedElementsAreMatcher::new([$(Box::new($matcher)),*], Requirements::Subset)
+        use $crate::matcher_support::__internal_unstable_do_not_depend_on_these::auto_eq;
+        UnorderedElementsAreMatcher::new([$(Box::new(auto_eq!($matcher))),*], Requirements::Subset)
     }}
 }
 

--- a/googletest/tests/elements_are_matcher_test.rs
+++ b/googletest/tests/elements_are_matcher_test.rs
@@ -139,3 +139,8 @@ fn elements_are_works_when_matcher_is_created_in_subroutine() -> Result<()> {
 fn elements_are_implicitly_called() -> Result<()> {
     verify_that!(vec![1, 2, 3], [eq(&1), eq(&2), eq(&3)])
 }
+
+#[test]
+fn elements_are_with_auto_eq() -> Result<()> {
+    verify_that!(vec![1, 2, 3], [&1, &2, lt(&43)])
+}

--- a/googletest/tests/unordered_elements_are_matcher_test.rs
+++ b/googletest/tests/unordered_elements_are_matcher_test.rs
@@ -448,3 +448,18 @@ fn is_contained_in_explains_mismatch_due_to_no_graph_matching_found() -> Result<
               Expected element `is greater than or equal to 3` at index 1 did not match any remaining actual element."))
     ))
 }
+
+#[test]
+fn unordered_elements_are_with_auto_eq() -> Result<()> {
+    verify_that!(vec![3, 4, 2], unordered_elements_are![&2, &3, &4])
+}
+
+#[test]
+fn contains_each_with_auto_eq() -> Result<()> {
+    verify_that!(vec![3, 4, 2], contains_each![&2, &4])
+}
+
+#[test]
+fn is_contained_in_with_auto_eq() -> Result<()> {
+    verify_that!(vec![3, 4, 2], is_contained_in![&1, &2, &3, &4])
+}


### PR DESCRIPTION
Use in macro may lead to surprising behavior as the imported symbol may clash with symbols passed as macro parameters.

Hence, it is better to:
* Full qualify when possible (for struct, macro, etc...)
* Underscore import traits for extension traits