### PR TITLE
Add fixtures support for sync test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     name: test (no default features) / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable, 1.66]
+        toolchain: [stable, 1.70.0]
     steps:
       - uses: actions/checkout@v4
       - name: Install ${{ matrix.toolchain }}
@@ -108,7 +108,7 @@ jobs:
     name: integration-test / ubuntu / ${{ matrix.toolchain }}
     strategy:
       matrix:
-        toolchain: [stable, 1.66.0, nightly, beta]
+        toolchain: [stable, 1.70.0, nightly, beta]
     steps:
       - uses: actions/checkout@v4
       - name: Install ${{ matrix.toolchain }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
 name = "googletest_macro"
 version = "0.12.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This library brings the rich assertion types of Google's C++ testing library
  * A new set of assertion macros offering similar functionality to those of
    [GoogleTest](https://google.github.io/googletest/primer.html#assertions).
 
-**The minimum supported Rust version is 1.66**.
+**The minimum supported Rust version is 1.70**.
 
 > :warning: The API is not fully stable and may still be changed until we
 > publish version 1.0.

--- a/googletest/Cargo.toml
+++ b/googletest/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/google/googletest-rust"
 readme = "../README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 authors = [
   "Bradford Hovinen <hovinen@google.com>",
   "Bastien Jacot-Guillarmod <bjacotg@google.com>",

--- a/googletest/src/fixtures.rs
+++ b/googletest/src/fixtures.rs
@@ -1,0 +1,261 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+    sync::{Mutex, OnceLock},
+};
+
+/// Interface for structure to be set up and torn down as part of a test.
+/// Types implementing `Fixture` can be passed as a reference argument to a
+/// test function.
+///
+/// ```ignore
+/// strct MyFixture { ... }
+///
+/// impl Fixture for MyFixture { ... }
+///
+/// #[googletest::test]
+/// fn test_with_fixture(my_fixture: &MyFixture) {...}
+/// ```
+pub trait Fixture: Sized {
+    /// Factory method of the `Fixture`.
+    ///
+    /// This method is called by the test harness before the test logic.
+    /// If this method returns an `Err(...)`, then the test logic is not
+    /// evaluated and only the fixtures previously set up are torn down.
+    fn set_up() -> crate::Result<Self>;
+
+    /// Clean up method for the fixture.
+    ///
+    /// This method is called by the test harness after the test logic.
+    /// If the `Fixture` has been set up, the test harness will call this
+    /// method, even if the test logic failed or panicked.
+    fn tear_down(self) -> crate::Result<()>;
+}
+
+/// Interface for structure to be set up before the test logic.
+/// Types implementing `ConsumableFixture` can be passed as a value argument to
+/// a test function.
+///
+/// ```ignore
+/// strct MyFixture { ... }
+///
+/// impl ConsumableFixture for MyFixture { ... }
+///
+/// #[googletest::test]
+/// fn test_with_fixture(my_fixture: MyFixture) {...}
+/// ```
+pub trait ConsumableFixture: Sized {
+    /// Factory method of the `ConsumableFixture`.
+    ///
+    /// This method is called by the test harness before the test logic.
+    /// If this method returns an `Err(...)`, then the test logic is not
+    /// evaluated.
+    fn set_up() -> crate::Result<Self>;
+}
+
+/// Generic adapter to implement `ConsumableFixture` on any type implementing
+/// `Default`.
+pub struct FixtureOf<T>(T);
+
+impl<T: Default> ConsumableFixture for FixtureOf<T> {
+    fn set_up() -> crate::Result<Self> {
+        Ok(Self(T::default()))
+    }
+}
+
+impl<T> Deref for FixtureOf<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for FixtureOf<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Interface for structure to be set up only once before all tests.
+/// Types implementing `StaticFixture` can be passed as a double referenced
+/// argument to a test function.
+///
+/// ```ignore
+/// strct MyFixture{ ... }
+///
+/// impl StaticFixture for MyFixture { ... }
+///
+/// #[googletest::test]
+/// fn test_with_fixture(my_fixture: &&MyFixture){...}
+/// ```
+pub trait StaticFixture: Sized + Sync + Send {
+    /// Factory method of the `StaticFixture`.
+    ///
+    /// This method is called by the test harness before the test logic.
+    /// If this method returns an `Err(...)`, then the test logic is not
+    /// evaluated.
+    fn set_up_once() -> crate::Result<Self>;
+}
+
+impl<F: StaticFixture + 'static> Fixture for &'static F {
+    fn set_up() -> crate::Result<Self> {
+        static ONCE_FIXTURE_REPO: OnceLock<
+            Mutex<HashMap<TypeId, &'static (dyn Any + Sync + Send)>>,
+        > = OnceLock::new();
+        let mut map = ONCE_FIXTURE_REPO.get_or_init(|| Mutex::new(HashMap::new())).lock()?;
+        let any =
+            map.entry(TypeId::of::<F>()).or_insert_with(|| Box::leak(Box::new(F::set_up_once())));
+        match any.downcast_ref::<crate::Result<F>>() {
+            Some(Ok(ref fixture)) => Ok(fixture),
+            Some(Err(e)) => Err(e.clone()),
+            None => panic!("Downcast failed. This is a bug in GoogleTest Rust"),
+        }
+    }
+
+    // Note that this is `&F` being torn down, not `F`.
+    fn tear_down(self) -> crate::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::sync::Once;
+
+    use super::FixtureOf;
+    use super::StaticFixture;
+    use crate as googletest;
+    use crate::prelude::*;
+    use crate::test;
+
+    #[test]
+    fn fixture_no_fixture() -> Result<()> {
+        Ok(())
+    }
+
+    struct AlwaysSucceed;
+
+    impl Fixture for AlwaysSucceed {
+        fn set_up() -> crate::Result<Self> {
+            Ok(Self)
+        }
+
+        fn tear_down(self) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn fixture_one_fixture(_: &AlwaysSucceed) -> Result<()> {
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_three_fixtures(
+        _: &AlwaysSucceed,
+        _: &AlwaysSucceed,
+        _: &AlwaysSucceed,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    struct NotAFixture {
+        a_field: i32,
+    }
+
+    impl Default for NotAFixture {
+        fn default() -> Self {
+            Self { a_field: 33 }
+        }
+    }
+
+    #[test]
+    fn fixture_of_non_fixture(not_a_fixture: FixtureOf<NotAFixture>) -> Result<()> {
+        verify_that!(not_a_fixture.a_field, eq(33))
+    }
+
+    #[test]
+    fn fixture_of_non_fixture_mut(mut not_a_fixture: FixtureOf<NotAFixture>) -> Result<()> {
+        not_a_fixture.a_field += 10;
+        verify_that!(not_a_fixture.a_field, eq(43))
+    }
+    struct PanickyFixture;
+
+    impl Fixture for PanickyFixture {
+        fn set_up() -> crate::Result<Self> {
+            Ok(Self)
+        }
+
+        fn tear_down(self) -> crate::Result<()> {
+            panic!("Whoooops");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Whoooops")]
+    fn fixture_teardown_called_even_if_test_fail(_: &PanickyFixture) {
+        panic!("Test failed");
+    }
+
+    struct FailingTearDown;
+
+    impl Fixture for FailingTearDown {
+        fn set_up() -> crate::Result<Self> {
+            Ok(Self)
+        }
+
+        fn tear_down(self) -> crate::Result<()> {
+            Err(googletest::TestAssertionFailure::create("It must fail!".into()))
+        }
+    }
+
+    struct OnlyOnce;
+
+    impl StaticFixture for OnlyOnce {
+        fn set_up_once() -> crate::Result<Self> {
+            static ONCE: Once = Once::new();
+            assert!(!ONCE.is_completed());
+            ONCE.call_once(|| {});
+            Ok(Self)
+        }
+    }
+
+    #[test]
+    fn static_fixture_works(_: &&OnlyOnce) {}
+
+    #[test]
+    fn static_fixture_same_static_fixture_twice(once: &&OnlyOnce, twice: &&OnlyOnce) {
+        // checks it points to the same memory address.
+        let once: *const OnlyOnce = *once;
+        let twice: *const OnlyOnce = *twice;
+        expect_eq!(once, twice);
+    }
+
+    struct AnotherStaticFixture;
+
+    impl StaticFixture for AnotherStaticFixture {
+        fn set_up_once() -> crate::Result<Self> {
+            Ok(Self)
+        }
+    }
+
+    #[test]
+    fn static_fixture_two_different_static_fixtures(_: &&OnlyOnce, _: &&AnotherStaticFixture) {}
+}

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -22,6 +22,7 @@ extern crate quickcheck;
 #[macro_use]
 pub mod assertions;
 pub mod description;
+pub mod fixtures;
 pub mod internal;
 pub mod matcher;
 pub mod matcher_support;
@@ -42,6 +43,7 @@ pub mod matchers;
 /// }
 /// ```
 pub mod prelude {
+    pub use super::fixtures::{ConsumableFixture, Fixture, FixtureOf, StaticFixture};
     pub use super::gtest;
     pub use super::matcher::{Matcher, MatcherBase};
     pub use super::matchers::*;

--- a/googletest_macro/Cargo.toml
+++ b/googletest_macro/Cargo.toml
@@ -28,6 +28,7 @@ authors = [
 [dependencies]
 quote = "1.0.33"
 syn = {version = "2.0.39", features = ["full"]}
+proc-macro2 = "1.0.85"
 
 [lib]
 name = "googletest_macro"

--- a/integration_tests/src/google_test_with_rstest.rs
+++ b/integration_tests/src/google_test_with_rstest.rs
@@ -78,4 +78,16 @@ mod tests {
     fn test_should_work_with_second_test_annotation() -> Result<()> {
         verify_that!(1, eq(1))
     }
+
+    #[rstest]
+    #[googletest::test]
+    fn test_should_work_with_rstest_no_return_first() {
+        expect_that!(1, eq(1));
+    }
+
+    #[googletest::test]
+    #[rstest]
+    fn test_should_work_with_rstest_no_return_second() {
+        expect_that!(1, eq(1));
+    }
 }


### PR DESCRIPTION
This is the first PR for adding support of fixtures in googletest, only focused on putting the capabilities for synchronous tests.

This also bumps the msrv to 1.70.