### PR TITLE
Make `expect_eq` and friends more hygienic

### DIFF
--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -571,13 +571,13 @@ macro_rules! expect_false {
 #[macro_export]
 macro_rules! verify_eq {
     ($actual:expr, [$($expected:expr),+ $(,)?] $(,)?) => {
-        verify_that!(&$actual, [$($crate::matchers::eq(&$expected)),*])
+        $crate::verify_that!(&$actual, [$($crate::matchers::eq(&$expected)),*])
     };
     ($actual:expr, {$($expected:expr),+ $(,)?} $(,)?) => {
-        verify_that!(&$actual, {$($crate::matchers::eq(&$expected)),*})
+        $crate::verify_that!(&$actual, {$($crate::matchers::eq(&$expected)),*})
     };
     ($actual:expr, $expected:expr $(,)?) => {
-        verify_that!(&$actual, $crate::matchers::eq(&$expected))
+        $crate::verify_that!(&$actual, $crate::matchers::eq(&$expected))
     };
 }
 
@@ -623,31 +623,31 @@ macro_rules! verify_eq {
 macro_rules! expect_eq {
     ($actual:expr, [$($expected:expr),+ $(,)?] $(,)?) => {{
         use $crate::GoogleTestSupport as _;
-        verify_eq!($actual, [$($expected),*]).and_log_failure();
+        $crate::verify_eq!($actual, [$($expected),*]).and_log_failure();
     }};
     ($actual:expr, [$($expected:expr),+ $(,)?], $($format_args:expr),* $(,)?) => {{
         use $crate::GoogleTestSupport as _;
-        verify_eq!($actual, [$($expected),*])
+        $crate::verify_eq!($actual, [$($expected),*])
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, {$($expected:expr),+ $(,)?} $(,)?) => {{
         use $crate::GoogleTestSupport as _;
-        verify_eq!($actual, {$($expected),*}).and_log_failure();
+        $crate::verify_eq!($actual, {$($expected),*}).and_log_failure();
     }};
     ($actual:expr, {$($expected:expr),+ $(,)?}, $($format_args:expr),* $(,)?) => {{
         use $crate::GoogleTestSupport as _;
-        verify_eq!($actual, {$($expected),*})
+        $crate::verify_eq!($actual, {$($expected),*})
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
         use $crate::GoogleTestSupport as _;
-        verify_eq!($actual, $expected).and_log_failure();
+        $crate::verify_eq!($actual, $expected).and_log_failure();
     }};
     ($actual:expr, $expected:expr, $($format_args:expr),* $(,)?) => {{
         use $crate::GoogleTestSupport as _;
-        verify_eq!($actual, $expected)
+        $crate::verify_eq!($actual, $expected)
             .with_failure_message(|| format!($($format_args),*))
             .and_log_failure();
     }};


### PR DESCRIPTION
Thanks for googletest-rust. It's been awesome to use :raised_hands: 

Currently, `expect_that!` doesn't work unless both `verify_eq!` and `verify_that` are in scope.

This is okay or users of the prelude, but not for those who don't.

I've noticed that googletest-rust has a number of other macro hygiene issues, but to avoid making an overly large PR, I'll address them as I come across them.