### PR TITLE
Make `result_of` explain the inner matcher failure

### DIFF
--- a/googletest/src/matchers/result_of_matcher.rs
+++ b/googletest/src/matchers/result_of_matcher.rs
@@ -115,9 +115,11 @@ pub mod internal {
 
         fn explain_match(&self, actual: I) -> Description {
             let actual_result = (self.callable)(actual);
-            Description::new()
-                .text(format!("which, results into {actual_result:?}",))
-                .nested(self.describe(self.matches(actual)))
+            Description::new().text(format!("which, results into {actual_result:?}")).nested(
+                Description::new()
+                    .text(format!("by applying {},", self.callable_description))
+                    .nested(self.inner_matcher.explain_match(actual_result)),
+            )
         }
     }
 
@@ -154,9 +156,11 @@ pub mod internal {
 
         fn explain_match(&self, actual: I) -> Description {
             let actual_result = (self.callable)(actual);
-            Description::new()
-                .text(format!("which, results into {actual_result:?}",))
-                .nested(self.describe(self.matches(actual)))
+            Description::new().text(format!("which, results into {actual_result:?}")).nested(
+                Description::new()
+                    .text(format!("by applying {},", self.callable_description))
+                    .nested(self.inner_matcher.explain_match(&actual_result)),
+            )
         }
     }
 }
@@ -192,7 +196,7 @@ mod tests {
                 Actual: 0,
                   which, results into -1
                     by applying |value| value - 1,
-                      isn't equal to 2
+                      which isn't equal to 2
                 "
             ))))
         )
@@ -211,7 +215,7 @@ mod tests {
                 Actual: 0,
                   which, results into -1
                     by applying |value| { value - 1 },
-                      isn't equal to 2
+                      which isn't equal to 2
                 "
             ))))
         )
@@ -240,7 +244,7 @@ mod tests {
                 Actual: 0,
                   which, results into -2
                     by applying |value| { let dec = value - 1; let inc = dec + 1; inc - 2 },
-                      isn't equal to 2
+                      which isn't equal to 2
                 "
             ))))
         )
@@ -262,7 +266,7 @@ mod tests {
                 Actual: 0,
                   which, results into -1
                     by applying dec_by_one,
-                      isn't equal to 2
+                      which isn't equal to 2
                 "
             ))))
         )
@@ -299,7 +303,7 @@ mod tests {
                 Actual: "world",
                   which, results into "WORLD"
                     by applying |s: &str| s.to_uppercase(),
-                      isn't equal to "HELLO""#
+                      which isn't equal to "HELLO""#
             ))))
         )
     }
@@ -318,7 +322,7 @@ mod tests {
             Actual: "world",
               which, results into "WORLD"
                 by applying |s: &str| { s.to_uppercase() },
-                  isn't equal to "HELLO"
+                  which isn't equal to "HELLO"
             "#
             ))))
         )
@@ -340,7 +344,7 @@ mod tests {
             Actual: "world",
               which, results into "WORLD"
                 by applying to_upper_case,
-                  isn't equal to "HELLO"
+                  which isn't equal to "HELLO"
             "#
             ))))
         )
@@ -360,7 +364,7 @@ mod tests {
                 Actual: "world",
                   which, results into "WORLD"
                     by applying to_upper_case,
-                      isn't equal to "HELLO"
+                      which isn't equal to "HELLO"
             "#
             ))))
         )
@@ -379,7 +383,7 @@ mod tests {
                 Actual: "world",
                   which, results into "WORLD"
                     by applying str::to_uppercase,
-                      isn't equal to "HELLO"
+                      which isn't equal to "HELLO"
             "#
             ))))
         )
@@ -401,7 +405,7 @@ mod tests {
             Actual: "world",
               which, results into "WORLD"
                 by applying upper_case(),
-                  isn't equal to "HELLO"
+                  which isn't equal to "HELLO"
             "#
             ))))
         )


### PR DESCRIPTION
Right now, `explain_match()` ends up calling the inner matcher's `describe()`. Although this works just fine for simple matchers, it falls apart for more complex ones, as it'll merely describe the matcher itself without including relevant intermediate values. For instance, this:

```rust
assert_that!(2, result_of!(|n| n, property!(i32.ilog2(), eq(10))));
```

results in:

```
Actual: 2,
  which, results into 2
    by applying |n| n,
      has property `ilog2()`, which isn't equal to 10
```

which omits the actual result of invoking the property.

By having it invoke `explain_match()`, we instead get the complete explanation:

```
Actual: 2,
  which, results into 2
    by applying |n| n,
      whose property `ilog2()` is `1`, which isn't equal to 10
```