### PR TITLE
Rename the shadowing module from "ctor" to "core".

### DIFF
--- a/integration_tests/src/macro_hygiene.rs
+++ b/integration_tests/src/macro_hygiene.rs
@@ -16,7 +16,7 @@ fn main() {}
 
 // Shadow important modules that the macros use.
 mod std {}
-mod ctor {}
+mod core {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Given the description of the commit that added macro_hygiene.rs, I believe that the name of the "ctor" module in this test should be "core", verifying that macros work properly when a crate under test has declared its own core module.