### PR TITLE
Fix Clippy warnings

### DIFF
--- a/googletest/src/fmt.rs
+++ b/googletest/src/fmt.rs
@@ -28,7 +28,7 @@ pub mod internal {
     /// Used for autoref specialization to conditionally
     /// render only values that implement `Debug`. See also
     /// [`FormatNonDebugFallback`].
-    impl<'a, T: Debug + ?Sized> FormatWrapper<'a, T> {
+    impl<T: Debug + ?Sized> FormatWrapper<'_, T> {
         #[track_caller]
         pub fn __googletest_write_expr_value(&self, output: &mut dyn Write, expr_label: &str) {
             write!(output, "\n  {} = {:?},", expr_label, self.0)
@@ -45,7 +45,7 @@ pub mod internal {
         fn __googletest_write_expr_value(&self, output: &mut dyn Write, expr_label: &str);
     }
 
-    impl<'a, T: ?Sized> FormatNonDebugFallback for FormatWrapper<'a, T> {
+    impl<T: ?Sized> FormatNonDebugFallback for FormatWrapper<'_, T> {
         #[track_caller]
         fn __googletest_write_expr_value(&self, output: &mut dyn Write, expr_label: &str) {
             write!(output, "\n  {} does not implement Debug,", expr_label)

--- a/googletest/src/matcher.rs
+++ b/googletest/src/matcher.rs
@@ -32,7 +32,6 @@ use std::fmt::Debug;
 /// on, up to 12 elements. Tuples longer than that do not automatically inherit
 /// the `Debug` trait from their members, so are generally not well-supported;
 /// see [Rust by Example](https://doc.rust-lang.org/rust-by-example/primitives/tuples.html#tuples).
-
 // `ActualT` requires `Copy` so that `actual` could be passed to `matches` and
 // if it fails passed to `explain_match`. We can relax this constraint later by
 // requiring only `Clone`.

--- a/googletest/src/matcher_support/auto_eq.rs
+++ b/googletest/src/matcher_support/auto_eq.rs
@@ -50,7 +50,7 @@ pub mod internal {
 
     pub struct Wrapper<T>(pub T);
 
-    impl<'a, T: MatcherBase> Wrapper<&'a T> {
+    impl<T: MatcherBase> Wrapper<&'_ T> {
         #[inline]
         pub fn kind(&self) -> MatcherTag {
             MatcherTag

--- a/googletest/src/matcher_support/summarize_diff.rs
+++ b/googletest/src/matcher_support/summarize_diff.rs
@@ -234,7 +234,7 @@ impl<'a> FromIterator<edit_distance::Edit<&'a str>> for BufferedSummary<'a> {
     }
 }
 
-impl<'a> Display for BufferedSummary<'a> {
+impl Display for BufferedSummary<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if !matches!(self.buffer, Buffer::Empty) {
             panic!("Buffer is not empty. This is a bug in gtest_rust.")
@@ -307,7 +307,7 @@ impl<'a> Buffer<'a> {
     }
 }
 
-impl<'a> Default for Buffer<'a> {
+impl Default for Buffer<'_> {
     fn default() -> Self {
         Self::Empty
     }

--- a/googletest/src/matchers/elements_are_matcher.rs
+++ b/googletest/src/matchers/elements_are_matcher.rs
@@ -125,7 +125,7 @@ pub mod internal {
         }
     }
 
-    impl<'a, T: Debug + Copy, ContainerT: Debug + Copy> Matcher<ContainerT> for ElementsAre<'a, T>
+    impl<T: Debug + Copy, ContainerT: Debug + Copy> Matcher<ContainerT> for ElementsAre<'_, T>
     where
         ContainerT: IntoIterator<Item = T>,
     {

--- a/googletest/src/matchers/is_matcher.rs
+++ b/googletest/src/matchers/is_matcher.rs
@@ -35,8 +35,8 @@ pub struct IsMatcher<'a, InnerMatcherT> {
     inner: InnerMatcherT,
 }
 
-impl<'a, ActualT: Debug + Copy, InnerMatcherT: Matcher<ActualT>> Matcher<ActualT>
-    for IsMatcher<'a, InnerMatcherT>
+impl<ActualT: Debug + Copy, InnerMatcherT: Matcher<ActualT>> Matcher<ActualT>
+    for IsMatcher<'_, InnerMatcherT>
 {
     fn matches(&self, actual: ActualT) -> MatcherResult {
         self.inner.matches(actual)

--- a/googletest/src/matchers/unordered_elements_are_matcher.rs
+++ b/googletest/src/matchers/unordered_elements_are_matcher.rs
@@ -344,8 +344,8 @@ pub mod internal {
     // least one expected element and vice versa.
     // 3. `UnorderedElementsAreMatcher` verifies that a perfect matching exists
     // using Ford-Fulkerson.
-    impl<'a, T: Debug + Copy, ContainerT: Debug + Copy, const N: usize> Matcher<ContainerT>
-        for UnorderedElementsAreMatcher<'a, T, N>
+    impl<T: Debug + Copy, ContainerT: Debug + Copy, const N: usize> Matcher<ContainerT>
+        for UnorderedElementsAreMatcher<'_, T, N>
     where
         ContainerT: IntoIterator<Item = T>,
     {


### PR DESCRIPTION
Fix Clippy warnings:

* warning: the following explicit lifetimes could be elided

* warning: empty line after doc comment