### PR TITLE
Remove irrelevant package ecosystems from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,76 +1,9 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-  open-pull-requests-limit: 3
-- package-ecosystem: gomod
-  directory: "/tools"
-  schedule:
-    interval: daily
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-  open-pull-requests-limit: 3
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
       interval: "daily"
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-  open-pull-requests-limit: 3
-- package-ecosystem: docker
-  directory: "/cron/internal/bq"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-  open-pull-requests-limit: 3
-- package-ecosystem: docker
-  directory: "/cron/internal/worker"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/cron/internal/webhook"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/cron/internal/controller"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/cron/internal/cii"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/clients/githubrepo/roundtripper/tokens/server"
-  schedule:
-    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"


### PR DESCRIPTION
This change removes Go and Docker package ecosystems from `dependabot.yml` since we don't use them.