### PR TITLE
Make Result parametric in the error type as well

### DIFF
--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -91,7 +91,7 @@ use internal::test_outcome::{TestAssertionFailure, TestOutcome};
 /// of the (fatal) assertion failure which generated this result. Non-fatal
 /// assertion failures, which log the failure and report the test as having
 /// failed but allow it to continue running, are not encoded in this type.
-pub type Result<T> = std::result::Result<T, TestAssertionFailure>;
+pub type Result<T, E = TestAssertionFailure> = std::result::Result<T, E>;
 
 /// Returns a [`Result`] corresponding to the outcome of the currently running
 /// test.

--- a/googletest_macro/src/lib.rs
+++ b/googletest_macro/src/lib.rs
@@ -123,7 +123,7 @@ pub fn gtest(
     };
 
     let (output_type, result) = match sig.output {
-        ReturnType::Default => (None, quote! {googletest::Result::Ok(())}),
+        ReturnType::Default => (None, quote! {googletest::Result::<()>::Ok(())}),
         ReturnType::Type(_, ref ty) => (Some(quote! {#ty}), quote! {result}),
     };
 


### PR DESCRIPTION
This make `googletest::Result` similar to `std::result::Result` and can be used from one another. This plays nicer when `googletest::Result` is included through the `prelude` and the user would like to use something like `Result<(), MyError>`.

This is a similar trick used by anyhow.