### PR TITLE
Fix mismatched-lifetime-syntaxes in googletest_macro.

### DIFF
--- a/googletest_macro/src/lib.rs
+++ b/googletest_macro/src/lib.rs
@@ -428,7 +428,7 @@ pub fn __abbreviated_stringify(input: proc_macro::TokenStream) -> proc_macro::To
     .into()
 }
 
-fn abbreviated_string(target: &str) -> Result<std::borrow::Cow<str>, &'static str> {
+fn abbreviated_string(target: &str) -> Result<std::borrow::Cow<'_, str>, &'static str> {
     use std::borrow::Cow;
     match target.rsplit_once(',') {
         None => Err("Expect a `max_length` argument, but got none"),


### PR DESCRIPTION
The error is something like:

```
error: hiding a lifetime that's elided elsewhere is confusing
   --> third_party/gtest_rust/googletest_macro/src/lib.rs:446:31
    |
446 | fn abbreviated_string(target: &str) -> Result<std::borrow::Cow<str>, &'static str> {
    |                               ^^^^            --------------------- the same lifetime is hidden here
    |                               |
    |                               the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: requested on the command line with `-F mismatched-lifetime-syntaxes`
help: use `'_` for type paths
    |
446 | fn abbreviated_string(target: &str) -> Result<std::borrow::Cow<'_, str>, &'static str> {
```

We disabled this lint internally to google (b/426462533 if you're watching), but this affects anyone using this crate but not disabling the lint. Also, probably want to fix it before we re-enable the lint.