### PR TITLE
fix usage of undefined env. var in itests

### DIFF
--- a/integration_tests/src/integration_tests.rs
+++ b/integration_tests/src/integration_tests.rs
@@ -18,6 +18,7 @@ fn main() {}
 mod tests {
     use googletest::prelude::*;
     use indoc::indoc;
+    use std::path::Path;
     use std::process::Command;
 
     #[gtest]
@@ -2095,10 +2096,11 @@ mod tests {
     }
 
     fn run_external_process(name: &'static str) -> Command {
-        let command_path = format!(
-            "./{}/debug/{name}",
-            std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into())
-        );
+        let command_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("target")
+            .join("debug")
+            .join(name);
         let mut command = Command::new(command_path);
         // For test hermeticity, clear the env.  Integration testing
         // depends on implicit output capturing (RUST_TEST_NOCAPTURE


### PR DESCRIPTION
so far, the integration tests relied on the `CARGO_TARGET_DIR` env. variable. this usage was wrong since the variable is not actually set, so the fallback `"target"` was always used.

`CARGO_MANIFEST_DIR` is always set and we know that the target directory is one level up from there, so we can use that instead. `std::path::Path` is used to ensure that the correct path separator is used.

the `run_integration_tests.sh` script is not affected by this since it is meant to be launched from the project root directory and then the path constructed so far already worked. but if running the tests e.g. from an IDE (after compiling the itest binaries) then the working directory will be in the `integration_tests` subfolder and the constructed path will be wrong (this is how i initially noticed this bug).