### PR TITLE
Fix macro hygiene by qualifying format! as ::core::format!

### DIFF
--- a/googletest/src/assertions.rs
+++ b/googletest/src/assertions.rs
@@ -299,7 +299,7 @@ pub use verify_pred;
 macro_rules! fail {
     ($($message:expr),+ $(,)?) => {{
         $crate::assertions::internal::create_fail_result(
-            format!($($message),*),
+            ::core::format!($($message),*),
         )
     }};
 
@@ -332,7 +332,7 @@ macro_rules! succeed {
     ($($message:expr),+ $(,)?) => {{
         println!(
             "{}\n at {}:{}:{}",
-            format!($($message),*),
+            ::core::format!($($message),*),
             file!(), line!(), column!()
         );
     }};
@@ -376,7 +376,7 @@ macro_rules! add_failure {
     ($($message:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure(
         $crate::assertions::internal::create_fail_result(
-            format!($($message),*),
+            ::core::format!($($message),*),
         ));
     }};
 
@@ -425,7 +425,7 @@ macro_rules! add_failure_at {
     ($file:expr, $line:expr, $column:expr, $($message:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure(
         $crate::assertions::internal::create_fail_result(
-            format!($($message),*),
+            ::core::format!($($message),*),
         ).map_err(|e| e.with_fake_location($file, $line, $column)));
     }};
 
@@ -519,7 +519,7 @@ macro_rules! expect_true {
     ($condition:expr, $($format_args:expr),* $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_true!($condition),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
 }
 pub use expect_true;
@@ -576,7 +576,7 @@ macro_rules! assert_true {
     ($condition:expr, $($format_args:expr),* $(,)?) => {
         if let Err(e) = $crate::GoogleTestSupport::with_failure_message(
             $crate::verify_true!($condition),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
         {
             panic!("\n{}", e);
         }
@@ -668,7 +668,7 @@ macro_rules! expect_false {
     ($condition:expr, $($format_args:expr),* $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_false!($condition),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
     }};
 }
 pub use expect_false;
@@ -724,7 +724,7 @@ macro_rules! assert_false {
     ($condition:expr, $($format_args:expr),* $(,)?) => {
         if let Err(e) = $crate::GoogleTestSupport::with_failure_message(
             $crate::verify_false!($condition),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
         {
             panic!("\n{}", e);
         }
@@ -856,7 +856,7 @@ macro_rules! expect_eq {
     ($actual:expr, [$($expected:expr),+ $(,)?], $($format_args:expr),* $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_eq!($actual, [$($expected),*]),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, {$($expected:expr),+ $(,)?} $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure($crate::verify_eq!($actual, {$($expected),*}));
@@ -864,7 +864,7 @@ macro_rules! expect_eq {
     ($actual:expr, {$($expected:expr),+ $(,)?}, $($format_args:expr),* $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_eq!($actual, {$($expected),*}),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure($crate::verify_eq!($actual, $expected));
@@ -872,7 +872,7 @@ macro_rules! expect_eq {
     ($actual:expr, $expected:expr, $($format_args:expr),* $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_eq!($actual, $expected),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
 }
 pub use expect_eq;
@@ -947,7 +947,7 @@ macro_rules! expect_ne {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_ne!($actual, $expected),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure($crate::verify_ne!($actual, $expected));
@@ -1025,7 +1025,7 @@ macro_rules! expect_lt {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_lt!($actual, $expected),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
        $crate::GoogleTestSupport::and_log_failure($crate::verify_lt!($actual, $expected));
@@ -1104,7 +1104,7 @@ macro_rules! expect_le {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_le!($actual, $expected),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure($crate::verify_le!($actual, $expected));
@@ -1182,7 +1182,7 @@ macro_rules! expect_gt {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_gt!($actual, $expected),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure($crate::verify_gt!($actual, $expected));
@@ -1262,7 +1262,7 @@ macro_rules! expect_ge {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_ge!($actual, $expected),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure($crate::verify_ge!($actual, $expected));
@@ -1357,7 +1357,7 @@ macro_rules! expect_float_eq {
     ($actual:expr, $expected:expr, $($format_args:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_float_eq!($actual, $expected),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, $expected:expr $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure($crate::verify_float_eq!($actual, $expected));
@@ -1438,7 +1438,7 @@ macro_rules! expect_near {
     ($actual:expr, $expected:expr, $max_abs_error:expr, $($format_args:expr),+ $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_near!($actual, $expected, $max_abs_error),
-            || format!($($format_args),*));
+            || ::core::format!($($format_args),*));
     }};
     ($actual:expr, $expected:expr, $max_abs_error:expr $(,)?) => {{
         $crate::GoogleTestSupport::and_log_failure($crate::verify_near!($actual, $expected, $max_abs_error));
@@ -1522,7 +1522,7 @@ macro_rules! assert_that {
     ($actual:expr, [ $($expected:expr),* ], $($format_args:expr),* $(,)?) => {
         match $crate::GoogleTestSupport::with_failure_message(
             $crate::verify_that!($actual, [ $($expected),* ]),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
         {
             Ok(_) => {}
             Err(e) => {
@@ -1537,7 +1537,7 @@ macro_rules! assert_that {
     ($actual:expr, { $($expected:expr),* }, $($format_args:expr),* $(,)?) => {
         match $crate::GoogleTestSupport::with_failure_message(
             $crate::verify_that!($actual, { $($expected),* }),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
         {
             Ok(_) => {}
             Err(e) => {
@@ -1564,7 +1564,7 @@ macro_rules! assert_that {
     ($actual:expr, $expected:expr, $($format_args:expr),* $(,)?) => {
         match $crate::GoogleTestSupport::with_failure_message(
             $crate::verify_that!($actual, $expected),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
         {
             Ok(_) => {}
             Err(e) => {
@@ -1621,7 +1621,7 @@ macro_rules! assert_pred {
     ($content:expr $(,)?, $($format_args:expr),* $(,)?) => {
         match $crate::GoogleTestSupport::with_failure_message(
             $crate::verify_pred!($content),
-            || format!($($format_args),*)
+            || ::core::format!($($format_args),*)
         ) {
             Ok(_) => {}
             Err(e) => {
@@ -1692,14 +1692,14 @@ macro_rules! expect_that {
     ($actual:expr, [$($expected:expr),*], $($format_args:expr),* $(,)?) => {
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_that!($actual, [$($expected),*]),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
     };
 
     // w/ format args, specialized to unordered sequence:
     ($actual:expr, {$($expected:expr),*}, $($format_args:expr),* $(,)?) => {
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_that!($actual, {$($expected),*}),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
     };
 
     // general case:
@@ -1711,7 +1711,7 @@ macro_rules! expect_that {
     ($actual:expr, $expected:expr, $($format_args:expr),* $(,)?) => {
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_that!($actual, $expected),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
     };
 }
 pub use expect_that;
@@ -1761,7 +1761,7 @@ macro_rules! expect_pred {
     ($content:expr $(,)?, $($format_args:expr),* $(,)?) => {
         $crate::GoogleTestSupport::and_log_failure_with_message(
             $crate::verify_pred!($content),
-            || format!($($format_args),*))
+            || ::core::format!($($format_args),*))
     };
 }
 pub use expect_pred;

--- a/googletest/src/lib.rs
+++ b/googletest/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! scoped_trace {
     ($($arg:tt)*) => {
         #[allow(clippy::shadow_same, clippy::shadow_unrelated)]
         let _gtest_trace_guard = $crate::internal::scoped_trace::ScopedTraceGuard::new(
-            format!($($arg)*),
+            ::core::format!($($arg)*),
         );
     };
 }

--- a/googletest/src/matchers/tuple_matcher.rs
+++ b/googletest/src/matchers/tuple_matcher.rs
@@ -82,7 +82,7 @@ pub mod internal {
                         MatcherResult::Match => {},
                         MatcherResult::NoMatch => {
                             explanation = explanation
-                                .text(format!(concat!("Element #", $field_number, " is {:?},"),
+                                .text(::core::format!(concat!("Element #", $field_number, " is {:?},"),
                                     actual.$field_number))
                                 .nested(self.$field_number.explain_match(actual.$field_number));
                         }
@@ -132,7 +132,7 @@ pub mod internal {
                         MatcherResult::Match => {},
                         MatcherResult::NoMatch => {
                             explanation = explanation
-                                .text(format!(
+                                .text(::core::format!(
                                     concat!(
                                         "Element #",
                                         $field_number,


### PR DESCRIPTION
## Description

All `format!` calls inside `macro_rules!` expansion bodies now use `::core::format!` instead of the unqualified `format!`. This ensures the macros work correctly even when a user has their own `format!` macro in scope, which is a best practice for robust macro definitions.

Given:
```rust
expect_that!(x, eq(y), "{}", z());
```
Previously this would expand to an unqualified `format!`, causing ambiguity or incorrect resolution when the user's crate re-exports a `format!` macro. Now it correctly uses `::core::format!`.

## Changes

- `googletest/src/assertions.rs`: 26 occurrences across 20 macros
- `googletest/src/lib.rs`: 1 occurrence in `scoped_trace!`
- `googletest/src/matchers/tuple_matcher.rs`: 2 occurrences in `tuple_matcher_n!`

Fixes #819
