### PR TITLE
fix: silence clippy::unnecessary_self_imports in matches_pattern_internal!

### DIFF
--- a/googletest/src/matchers/matches_pattern.rs
+++ b/googletest/src/matchers/matches_pattern.rs
@@ -304,6 +304,7 @@ macro_rules! __matches_pattern {
 macro_rules! matches_pattern_internal {
     ($($tt:tt)*) => {
         {
+            #[allow(clippy::unnecessary_self_imports)]
             use $crate::{self as googletest};
             #[allow(unused)]
             use $crate::matchers::{all, field, property};


### PR DESCRIPTION
`clippy::unnecessary_self_imports` triggers when the `matches_pattern_internal!` macro expands. Users enabling this lint shan't care about what the macro expands to

Ultimately, this avoids a global allow for this lint in test code

I tested with this patch against a local repo and the lint was supressed