### PR TITLE
chore: fix CONTRIBUTING.md link for crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ displayed, we recommend setting those variables in the personal
 
 ## Contributing Changes
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute
+Please read [CONTRIBUTING.md](https://github.com/google/googletest-rust/blob/main/CONTRIBUTING.md) for details on how to contribute
 to this project.
 
 [`and_log_failure()`]: https://docs.rs/googletest/*/googletest/trait.GoogleTestSupport.html#tymethod.and_log_failure


### PR DESCRIPTION
On crates.io, the CONTRIBUTING.md link points to the googletest crate root (https://github.com/google/googletest-rust/blob/HEAD/googletest/CONTRIBUTING.md). This is since the crate uses a relative path to point to the README, which then resolves the CONTRIBUTING.md relatively from a different root

This fix makes the path absolute to work on both GitHub and crates